### PR TITLE
feat: Add changedetection and gluetun-proxy apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ Brewfile.lock.json
 wiki
 # Bootstrap
 /config.yaml
+
+!AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,804 @@
 ---
-description: Guidelines for translating apps from Flux to Argo CD
+description: Guidelines for developing and maintaining applications in the home-cluster
 ---
 
-See `.agents/workflows/translate-flux-to-argo.md` in the project root for instructions on translating Flux HelmRelease resources to Argo CD Applications.
+# Home Cluster Application Guidelines
 
-When translating apps:
-1. Follow the directory structure conventions
-2. Use ksops for secrets
-3. Configure ingresses with laboratory.casa domain
-4. Set up persistence using the documented patterns
-5. Use the standard app-template chart version (4.6.2)
+This document provides comprehensive guidelines for developing, deploying, and maintaining applications in the home-cluster using Argo CD and the bjw-s app-template Helm chart.
+
+## Important: GitOps Workflow
+
+**This cluster uses a GitOps approach with Argo CD.** 
+
+- **NEVER** attempt to deploy changes directly to the Kubernetes cluster (no `kubectl apply`, `helm install`, etc.)
+- **NEVER** run commands that interact with the cluster API
+- All changes are made by editing files in the repository, committing, and pushing
+- Argo CD automatically detects changes and reconciles the cluster state
+
+**Workflow:**
+1. Edit the necessary files (values.yaml, Application definitions, secrets, etc.)
+2. Commit the changes to Git
+3. Push to the repository
+4. Argo CD will automatically sync and deploy the changes
+
+## Table of Contents
+
+1. [Directory Structure](#directory-structure)
+2. [Argo CD Application Definition](#argo-cd-application-definition)
+3. [Values.yaml Configuration](#valuesyaml-configuration)
+4. [Secrets Management with ksops](#secrets-management-with-ksops)
+5. [Ingress Configuration](#ingress-configuration)
+6. [Persistence Configuration](#persistence-configuration)
+7. [Security Context](#security-context)
+8. [Common Patterns](#common-patterns)
+9. [Anti-patterns to Avoid](#anti-patterns-to-avoid)
+
+---
+
+## Directory Structure
+
+Each application follows a consistent directory structure:
+
+```
+kubernetes/apps/<namespace>/<app-name>/
+├── kustomization.yaml          # Required if using secrets or configmaps
+├── values.yaml                 # Helm chart values
+├── secret-generator.yaml       # ksops generator (if secrets needed)
+├── <app-name>-secret.sops.yaml # SOPS-encrypted secrets (if needed)
+└── <config-file>.yaml          # Additional configs (configmaps, etc.)
+
+kubernetes/argo/apps/<namespace>/<app-name>.yaml  # Argo CD Application definition
+```
+
+**Notes:**
+- Each app typically has its own namespace with the same name as the app (e.g., `mealie` app in `mealie` namespace)
+- Apps can be grouped by function (e.g., `homeassistant/`, `database/`, `security/`, `network/`)
+- The inner directory name should match the app name
+
+**Examples:**
+- Simple app: `kubernetes/apps/mealie/mealie/`
+- Grouped apps: `kubernetes/apps/homeassistant/zigbee2mqtt/`
+- System apps: `kubernetes/apps/security/authelia/`
+
+---
+
+## Argo CD Application Definition
+
+Every app needs an Argo CD Application resource at `kubernetes/argo/apps/<namespace>/<app-name>.yaml`:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: <app-name>
+  namespace: argo-system
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  project: kubernetes
+  sources:
+    - repoURL: https://github.com/mebezac/home-cluster.git
+      path: kubernetes/apps/<namespace>/<app-name>
+      targetRevision: main
+      ref: <app-name>-repo
+    - repoURL: ghcr.io/bjw-s-labs/helm
+      chart: app-template
+      targetRevision: 4.6.2
+      helm:
+        releaseName: <app-name>
+        valueFiles:
+          - $<app-name>-repo/kubernetes/apps/<namespace>/<app-name>/values.yaml
+  destination:
+    name: in-cluster
+    namespace: <namespace>
+  syncPolicy:
+    automated:
+      allowEmpty: true
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+```
+
+**Key points:**
+- Always use `ghcr.io/bjw-s-labs/helm` as the chart repository (NOT `https://bjw-s.github.io/helm-charts/`)
+- Standard app-template version is **4.6.2**
+- The `ref` name must match the pattern `<app-name>-repo`
+- Value files are referenced using `$<app-name>-repo/...` syntax
+
+---
+
+## Values.yaml Configuration
+
+### Basic Structure
+
+```yaml
+# Optional: Default pod options applied to all pods
+defaultPodOptions:
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 3000
+    runAsGroup: 3000
+    fsGroup: 3000
+    fsGroupChangePolicy: OnRootMismatch
+    seccompProfile: { type: RuntimeDefault }
+
+controllers:
+  <controller-name>:  # Usually 'main' or the app name
+    annotations:
+      reloader.stakater.com/auto: "true"  # Auto-reload on secret/configmap changes
+    containers:
+      app:  # Container name, usually 'app' or 'main'
+        image:
+          repository: ghcr.io/example/app
+          tag: 1.0.0@sha256:abc123...  # Pin with SHA for reproducibility
+        env:
+          TZ: America/New_York  # Always use explicit timezone, not variables
+        resources:
+          requests:
+            cpu: 10m
+            memory: 128Mi
+          limits:
+            memory: 512Mi
+
+service:
+  app:
+    controller: <controller-name>
+    ports:
+      http:
+        port: 8080
+
+ingress:
+  app:
+    enabled: true
+    className: internal
+    hosts:
+      - host: <app-name>.laboratory.casa
+        paths:
+          - path: /
+            service:
+              identifier: app
+              port: http
+
+persistence:
+  data:
+    type: persistentVolumeClaim
+    storageClass: longhorn
+    accessMode: ReadWriteOnce
+    size: 1Gi
+    globalMounts:
+      - path: /data
+```
+
+### Image Tags
+
+Prefer pinning images with SHA256 digests for reproducibility:
+
+```yaml
+image:
+  repository: ghcr.io/example/app
+  tag: 1.0.0@sha256:abc123def456...
+```
+
+For frequently updated apps where you want automatic updates, a simple tag is acceptable:
+
+```yaml
+image:
+  repository: ghcr.io/example/app
+  tag: 1.0.0
+```
+
+### Environment Variables
+
+**DO:**
+- Use explicit values for timezone: `TZ: America/New_York`
+- Reference secrets via `envFrom`:
+  ```yaml
+  envFrom:
+    - secretRef:
+        name: <app-name>-secret
+  ```
+- Use YAML anchors for reuse:
+  ```yaml
+  envFrom: &envFrom
+    - secretRef:
+        name: app-secret
+  # Later in the file:
+  envFrom: *envFrom
+  ```
+
+**DON'T:**
+- Use variable substitution like `${TIMEZONE}` or `${VOLSYNC_CLAIM}` - these are Flux patterns
+- Hardcode secrets in values.yaml
+
+### Port References
+
+Use YAML anchors for port consistency:
+
+```yaml
+containers:
+  app:
+    env:
+      PORT: &port 8080
+service:
+  app:
+    ports:
+      http:
+        port: *port
+```
+
+---
+
+## Secrets Management with ksops
+
+### Required Files
+
+When an app needs secrets, create these files:
+
+**1. kustomization.yaml:**
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generators:
+  - secret-generator.yaml
+```
+
+**2. secret-generator.yaml:**
+```yaml
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: <app-name>-secret-generator
+  annotations:
+    config.kubernetes.io/function: |
+      exec:
+        path: ksops
+files:
+  - ./<app-name>-secret.sops.yaml
+```
+
+**3. <app-name>-secret.sops.yaml:** (encrypted with SOPS)
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <app-name>-secret
+  namespace: <namespace>
+type: Opaque
+stringData:
+  SECRET_KEY: encrypted-value
+```
+
+**Important:** When creating new secrets:
+- Create the secret file with plaintext values as a template
+- **Leave the SOPS encryption to the user** - never run or suggest running `sops --encrypt` commands
+- The user will encrypt the file themselves using their own age keys
+
+### Multiple Secrets
+
+For apps with multiple secrets (e.g., authelia):
+
+```yaml
+# secret-generator.yaml
+files:
+  - ./authelia-initdb-secret.sops.yaml
+  - ./authelia-oidc-private-key.sops.yaml
+  - ./authelia-secret.sops.yaml
+```
+
+### ConfigMaps
+
+For non-sensitive configuration files, use kustomize configMapGenerator:
+
+```yaml
+# kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+configMapGenerator:
+  - name: <app-name>-config
+    files:
+      - configuration.yaml=./<app-name>-config.yaml
+    options:
+      disableNameSuffixHash: true
+generators:
+  - secret-generator.yaml
+```
+
+---
+
+## Ingress Configuration
+
+### Internal Ingress (Default)
+
+For apps only accessible within the network:
+
+```yaml
+ingress:
+  app:
+    enabled: true
+    className: internal
+    hosts:
+      - host: <app-name>.laboratory.casa
+        paths:
+          - path: /
+            service:
+              identifier: app
+              port: http
+```
+
+### External Ingress
+
+For apps accessible from the internet:
+
+```yaml
+ingress:
+  app:
+    enabled: true
+    className: external
+    annotations:
+      external-dns.alpha.kubernetes.io/target: external.laboratory.casa
+    hosts:
+      - host: <app-name>.laboratory.casa
+        paths:
+          - path: /
+            service:
+              identifier: app
+              port: http
+```
+
+### With Authelia Authentication
+
+```yaml
+ingress:
+  app:
+    className: external
+    annotations:
+      external-dns.alpha.kubernetes.io/target: external.laboratory.casa
+      nginx.ingress.kubernetes.io/auth-method: GET
+      nginx.ingress.kubernetes.io/auth-url: http://authelia.security.svc.cluster.local/api/authz/auth-request
+      nginx.ingress.kubernetes.io/auth-signin: https://login.laboratory.casa?rm=$request_method
+      nginx.ingress.kubernetes.io/auth-response-headers: Remote-User,Remote-Name,Remote-Groups,Remote-Email
+    hosts:
+      - host: <app-name>.laboratory.casa
+        paths:
+          - path: /
+            service:
+              identifier: app
+              port: http
+```
+
+### Domain Guidelines
+
+- Primary domain: `laboratory.casa`
+- Use descriptive subdomains: `mealie.laboratory.casa`, `ha.laboratory.casa`
+- External services (like biglink.party) may have separate TLS configuration
+- Do NOT include TLS configuration for laboratory.casa - it's handled automatically
+
+---
+
+## Persistence Configuration
+
+### Standard Longhorn PVC (Most Common)
+
+```yaml
+persistence:
+  data:
+    type: persistentVolumeClaim
+    storageClass: longhorn
+    accessMode: ReadWriteOnce
+    size: 1Gi
+    suffix: data  # Optional: creates PVC named <app>-data
+    globalMounts:
+      - path: /data
+```
+
+### Multiple Mount Points from Single PVC
+
+```yaml
+persistence:
+  config:
+    type: persistentVolumeClaim
+    storageClass: longhorn
+    accessMode: ReadWriteOnce
+    size: 500Mi
+    suffix: config
+    globalMounts:
+      - path: /config
+        subPath: config
+      - path: /metadata
+        subPath: metadata
+```
+
+### EmptyDir (Temporary Data)
+
+```yaml
+persistence:
+  tmp:
+    type: emptyDir
+    globalMounts:
+      - path: /tmp
+  cache:
+    type: emptyDir
+    globalMounts:
+      - path: /app/.cache
+```
+
+### NFS Mounts (Media, Large Files)
+
+```yaml
+persistence:
+  media:
+    type: nfs
+    server: nas.laboratory.casa
+    path: /mnt/data/10tb/Media
+    globalMounts:
+      - path: /media
+```
+
+### Mounting Secrets as Files
+
+```yaml
+persistence:
+  secrets:
+    type: secret
+    name: <app-name>-secret
+    globalMounts:
+      - path: /config/secrets.yaml
+        subPath: secrets.yaml
+        readOnly: true
+```
+
+### Mounting ConfigMaps as Files
+
+```yaml
+persistence:
+  config-file:
+    type: configMap
+    name: <app-name>-config
+    advancedMounts:
+      main:
+        app:
+          - path: /config/configuration.yaml
+            subPath: configuration.yaml
+```
+
+### Advanced Mounts (Per-Controller/Container)
+
+For different mounts per container:
+
+```yaml
+persistence:
+  data:
+    type: persistentVolumeClaim
+    storageClass: longhorn
+    accessMode: ReadWriteOnce
+    size: 1Gi
+    advancedMounts:
+      <controller-name>:
+        <container-name>:
+          - path: /data
+            subPath: data
+            readOnly: false
+```
+
+### Storage Classes
+
+| Storage Class | Use Case |
+|---------------|----------|
+| `longhorn` | Default for all persistent data (replicated) |
+| `longhorn-single-replica` | Less critical data, saves space |
+| `openebs-hostpath` | High-performance local storage (e.g., transcodes) |
+| `freenas-api-nfs` | NFS-backed storage from TrueNAS |
+
+---
+
+## Security Context
+
+### Standard Security Context (Recommended)
+
+```yaml
+defaultPodOptions:
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 3000
+    runAsGroup: 3000
+    fsGroup: 3000
+    fsGroupChangePolicy: OnRootMismatch
+    seccompProfile: { type: RuntimeDefault }
+```
+
+### Container-Level Security
+
+```yaml
+containers:
+  app:
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+          - ALL
+```
+
+### Common User IDs
+
+| UID | Use Case |
+|-----|----------|
+| 3000 | Default for most apps |
+| 568 | Apps from k8s-at-home/bjw-s ecosystem |
+| 1000 | Generic unprivileged user |
+| 65534 | nobody user (most restrictive) |
+
+### Privileged Containers
+
+Only use when absolutely necessary (e.g., Home Assistant with USB devices):
+
+```yaml
+containers:
+  app:
+    securityContext:
+      privileged: true
+```
+
+---
+
+## Common Patterns
+
+### Apps with Database (PostgreSQL)
+
+```yaml
+controllers:
+  app:
+    annotations:
+      reloader.stakater.com/auto: "true"
+    initContainers:
+      init-db:
+        image:
+          repository: ghcr.io/home-operations/postgres-init
+          tag: 18.1
+        envFrom: &envFrom
+          - secretRef:
+              name: <app-name>-secret
+    containers:
+      app:
+        envFrom: *envFrom
+        env:
+          DB_TYPE: postgres
+          # ... other env vars
+```
+
+### Sidecar Containers
+
+```yaml
+controllers:
+  main:
+    containers:
+      app:
+        image:
+          repository: ghcr.io/example/app
+          tag: 1.0.0
+      browser:  # Sidecar container
+        image:
+          repository: ghcr.io/browserless/chrome
+          tag: v2.38.3
+        env:
+          SCREEN_WIDTH: "1920"
+```
+
+### CronJobs
+
+```yaml
+controllers:
+  ip-rotator:
+    type: cronjob
+    cronjob:
+      schedule: "15 * * * *"
+      successfulJobsHistory: 1
+      failedJobsHistory: 1
+    containers:
+      rotate:
+        image:
+          repository: curlimages/curl
+          tag: 8.18.0
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            echo "Running task..."
+```
+
+### LoadBalancer Services
+
+```yaml
+service:
+  main:
+    annotations:
+      lbipam.cilium.io/ips: 10.25.30.56
+    controller: main
+    type: LoadBalancer
+    ports:
+      http:
+        port: 8123
+```
+
+### Custom Health Probes
+
+```yaml
+containers:
+  app:
+    probes:
+      startup:
+        enabled: true
+        custom: true
+        spec:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          failureThreshold: 30
+      liveness:
+        enabled: true
+        custom: true
+        spec:
+          httpGet:
+            path: /healthz
+            port: 8080
+          periodSeconds: 10
+          failureThreshold: 3
+      readiness:
+        enabled: true
+        custom: true
+        spec:
+          httpGet:
+            path: /healthz
+            port: 8080
+          periodSeconds: 10
+          failureThreshold: 3
+```
+
+### Reloader Annotations
+
+Enable automatic pod restarts when secrets/configmaps change:
+
+```yaml
+controllers:
+  main:
+    annotations:
+      reloader.stakater.com/auto: "true"  # Auto-detect all secrets/configmaps
+      # OR be specific:
+      secret.reloader.stakater.com/reload: <secret-name>
+      configmap.reloader.stakater.com/reload: <configmap-name>
+```
+
+---
+
+## Anti-patterns to Avoid
+
+### 1. Flux Variable Substitution
+
+**Bad:**
+```yaml
+env:
+  TZ: ${TIMEZONE}
+persistence:
+  config:
+    existingClaim: "${VOLSYNC_CLAIM}"
+```
+
+**Good:**
+```yaml
+env:
+  TZ: America/New_York
+persistence:
+  config:
+    type: persistentVolumeClaim
+    storageClass: longhorn
+    accessMode: ReadWriteOnce
+    size: 1Gi
+```
+
+### 2. Old Helm Chart Repository
+
+**Bad:**
+```yaml
+repoURL: https://bjw-s.github.io/helm-charts/
+```
+
+**Good:**
+```yaml
+repoURL: ghcr.io/bjw-s-labs/helm
+```
+
+### 3. Missing Security Context
+
+**Bad:**
+```yaml
+controllers:
+  main:
+    containers:
+      app:
+        image: ...
+        # No security context
+```
+
+**Good:**
+```yaml
+defaultPodOptions:
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 3000
+    runAsGroup: 3000
+    fsGroup: 3000
+```
+
+### 4. Hardcoded Secrets
+
+**Bad:**
+```yaml
+env:
+  DATABASE_PASSWORD: mysecretpassword
+```
+
+**Good:**
+```yaml
+envFrom:
+  - secretRef:
+      name: app-secret
+```
+
+### 5. Missing Resource Limits
+
+**Bad:**
+```yaml
+containers:
+  app:
+    image: ...
+    # No resources defined
+```
+
+**Good:**
+```yaml
+containers:
+  app:
+    image: ...
+    resources:
+      requests:
+        cpu: 10m
+        memory: 128Mi
+      limits:
+        memory: 512Mi
+```
+
+### 6. Inconsistent Naming
+
+**Bad:**
+```yaml
+service:
+  myservice:
+    controller: main
+ingress:
+  myingress:
+    # ...
+    service:
+      identifier: differentname  # Doesn't match
+```
+
+**Good:**
+```yaml
+service:
+  app:
+    controller: main
+ingress:
+  app:
+    # ...
+    service:
+      identifier: app  # Matches service name
+```
+
+---
+
+## Additional Resources
+
+- See `.agents/workflows/translate-flux-to-argo.md` for migrating Flux apps
+- bjw-s app-template documentation: https://bjw-s-labs.github.io/helm-charts/
+- Argo CD documentation: https://argo-cd.readthedocs.io/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+---
+description: Guidelines for translating apps from Flux to Argo CD
+---
+
+See `.agents/workflows/translate-flux-to-argo.md` in the project root for instructions on translating Flux HelmRelease resources to Argo CD Applications.
+
+When translating apps:
+1. Follow the directory structure conventions
+2. Use ksops for secrets
+3. Configure ingresses with laboratory.casa domain
+4. Set up persistence using the documented patterns
+5. Use the standard app-template chart version (4.6.2)

--- a/kubernetes/apps/changedetection/changedetection/kustomization.yaml
+++ b/kubernetes/apps/changedetection/changedetection/kustomization.yaml
@@ -1,0 +1,2 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/kubernetes/apps/changedetection/changedetection/values.yaml
+++ b/kubernetes/apps/changedetection/changedetection/values.yaml
@@ -8,7 +8,7 @@ controllers:
           repository: ghcr.io/dgtlmoon/changedetection.io
           tag: 0.52.9@sha256:e95931043d68da46e90498ce74ad317b392caade07186dc06bdfa1710901bf90
         env:
-          TZ: ${TIMEZONE}
+          TZ: America/New_York
           PORT: &port 5000
           USE_X_SETTINGS: 1
           PLAYWRIGHT_DRIVER_URL: ws://localhost:3000/?stealth=1&--disable-web-security=true&--user-data-dir=~/browserless-cache-123
@@ -48,6 +48,8 @@ ingress:
 persistence:
   config:
     type: persistentVolumeClaim
-    existingClaim: "${VOLSYNC_CLAIM}"
+    storageClass: longhorn
+    accessMode: ReadWriteOnce
+    size: 512Mi
     globalMounts:
       - path: /datastore

--- a/kubernetes/apps/changedetection/changedetection/values.yaml
+++ b/kubernetes/apps/changedetection/changedetection/values.yaml
@@ -6,7 +6,7 @@ controllers:
       app:
         image:
           repository: ghcr.io/dgtlmoon/changedetection.io
-          tag: 0.52.7
+          tag: 0.52.9@sha256:e95931043d68da46e90498ce74ad317b392caade07186dc06bdfa1710901bf90
         env:
           TZ: ${TIMEZONE}
           PORT: &port 5000
@@ -14,8 +14,8 @@ controllers:
           PLAYWRIGHT_DRIVER_URL: ws://localhost:3000/?stealth=1&--disable-web-security=true&--user-data-dir=~/browserless-cache-123
       browser:
         image:
-          repository: browserless/chrome
-          tag: latest
+          repository: ghcr.io/browserless/chrome
+          tag: v2.38.3@sha256:a299ba3f59c5142d275d4cc68fe9aba8f1d528d32e4bd811f8198bb26198312e
           pullPolicy: IfNotPresent
         env:
           SCREEN_WIDTH: "1920"

--- a/kubernetes/apps/changedetection/changedetection/values.yaml
+++ b/kubernetes/apps/changedetection/changedetection/values.yaml
@@ -1,0 +1,53 @@
+controllers:
+  changedetection:
+    annotations:
+      reloader.stakater.com/auto: "true"
+    containers:
+      app:
+        image:
+          repository: ghcr.io/dgtlmoon/changedetection.io
+          tag: 0.52.7
+        env:
+          TZ: ${TIMEZONE}
+          PORT: &port 5000
+          USE_X_SETTINGS: 1
+          PLAYWRIGHT_DRIVER_URL: ws://localhost:3000/?stealth=1&--disable-web-security=true&--user-data-dir=~/browserless-cache-123
+      browser:
+        image:
+          repository: browserless/chrome
+          tag: latest
+          pullPolicy: IfNotPresent
+        env:
+          SCREEN_WIDTH: "1920"
+          SCREEN_HEIGHT: "1024"
+          SCREEN_DEPTH: "16"
+          ENABLE_DEBUGGER: "false"
+          PREBOOT_CHROME: "true"
+          CONNECTION_TIMEOUT: "300000"
+          MAX_CONCURRENT_SESSIONS: "10"
+          CHROME_REFRESH_TIME: "600000"
+          DEFAULT_BLOCK_ADS: "true"
+          DEFAULT_STEALTH: "true"
+service:
+  app:
+    controller: changedetection
+    ports:
+      http:
+        port: *port
+ingress:
+  app:
+    enabled: true
+    className: internal
+    hosts:
+      - host: changedetection.laboratory.casa
+        paths:
+          - path: /
+            service:
+              identifier: app
+              port: http
+persistence:
+  config:
+    type: persistentVolumeClaim
+    existingClaim: "${VOLSYNC_CLAIM}"
+    globalMounts:
+      - path: /datastore

--- a/kubernetes/apps/gluetun-proxy/gluetun-proxy/gluetun-proxy-secret.sops.yaml
+++ b/kubernetes/apps/gluetun-proxy/gluetun-proxy/gluetun-proxy-secret.sops.yaml
@@ -3,12 +3,28 @@
 apiVersion: v1
 kind: Secret
 metadata:
-    name: gluetun-proxy-secret
-    namespace: gluetun-proxy
+  name: gluetun-proxy-secret
+  namespace: gluetun-proxy
 type: Opaque
 stringData:
-    OPENVPN_USER: Windscribe-username
-    OPENVPN_PASSWORD: Windscribe-password
-    HTTPPROXY_USER: proxy-username
-    HTTPPROXY_PASSWORD: proxy-password
-    Windscribe_REGION: New York
+  OPENVPN_USER: ENC[AES256_GCM,data:C0JK7EsqEfyqwGchDSaPVQ==,iv:z72pBgz+dWziovxpgJZ9lifRSUyp8Xd64nSMzA4e30c=,tag:gCSp2t2jKwWx0JUHhPI2gA==,type:str]
+  OPENVPN_PASSWORD: ENC[AES256_GCM,data:af/FvcLnqlWAwQ==,iv:c3v7SOcXIL0Yj3oHXrDf7k35tpGRnsh+SmUYZhXVZ7o=,tag:Q0BX3sGEDdkxNTjwuMhqIA==,type:str]
+  HTTPPROXY_USER: ENC[AES256_GCM,data:1m0YjGPTqLqCXhIZMfZRpn8liQ==,iv:ooeRmnYA70K5kfNO+meJtVeuMYbKbgf1xLC4v54/LTk=,tag:usMjdO2MRf6Y/MGP3Ce9UQ==,type:str]
+  HTTPPROXY_PASSWORD: ENC[AES256_GCM,data:c5SAwa3tTXO2Oi7h532Z1FryOLDQmPbW85Whnjirlg==,iv:AcVNJ4iR4U7RQP9LlxUoiKMddw/ux+00Lp0sWjAZclo=,tag:S8GN1lWqk+rSNg78bgAhjQ==,type:str]
+  HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE: ENC[AES256_GCM,data:7w1oLHG+S3vtA1O/eTOl,iv:ArFJkkqtb4Ot3ZwZjcEAngYHfO4MQEPBwV7Ysr0VpBI=,tag:6zCNLZ9kt8umeYDQjUTy1w==,type:str]
+sops:
+  age:
+    - recipient: age1j7x3jkw82w02taqj8dmqplae07fxcrup2enejnta9z2v82fzsakqd4ka6p
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUSU0xbG4wYUk2dmFIOHNx
+        d29YZ1RaRzVobXk5RVJ2TmY2YjJzMTB4Mm00CmIraGRCYlRyQ3RETldTMC9GUklt
+        dTRCcDMzSVY0cWxZVkVuUDFJZjcvSTQKLS0tIENSd2gzWG1UY3AvSUhncHJ1aFVS
+        ejNmOCtBeXlydy9QZURUbDgySzV0LzgKERZV4n/5GW0cBXZid1vEGo4WdOgZXWV0
+        +woOlqKUS7MR4SUBeJDdzNzi/XozZMJd09Yyx8XTRx5GA1vEH3ipyA==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-01-25T22:09:54Z"
+  mac: ENC[AES256_GCM,data:DQ45LtpYcwA80I6NojepFCqipkQNXEpnDsJd/gjyoy212mw7gi3iBULsKmXPIcarUjz7zHclVoyYg1sSriB0bd94wMzpkr8n3xULIdgioAWzB/Z9UOOw/m96pU8rfUhob5rDRixyGz25ZV+S5NR+CjLEvNoa0+rFqoTiFZhCB+g=,iv:eZDj7vj+lR1u7ve3Xhqu6mqC3k2QVf2/vaAec+33+Ng=,tag:XkcQljlihilBWcmdMi6iDQ==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  mac_only_encrypted: true
+  version: 3.11.0

--- a/kubernetes/apps/gluetun-proxy/gluetun-proxy/gluetun-proxy-secret.sops.yaml
+++ b/kubernetes/apps/gluetun-proxy/gluetun-proxy/gluetun-proxy-secret.sops.yaml
@@ -1,0 +1,14 @@
+# This file will be encrypted with SOPS
+# Run: sops --encrypt --age <age-public-key> gluetun-proxy-secret.sops.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+    name: gluetun-proxy-secret
+    namespace: gluetun-proxy
+type: Opaque
+stringData:
+    OPENVPN_USER: Windscribe-username
+    OPENVPN_PASSWORD: Windscribe-password
+    HTTPPROXY_USER: proxy-username
+    HTTPPROXY_PASSWORD: proxy-password
+    Windscribe_REGION: New York

--- a/kubernetes/apps/gluetun-proxy/gluetun-proxy/kustomization.yaml
+++ b/kubernetes/apps/gluetun-proxy/gluetun-proxy/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generators:
+  - secret-generator.yaml

--- a/kubernetes/apps/gluetun-proxy/gluetun-proxy/secret-generator.yaml
+++ b/kubernetes/apps/gluetun-proxy/gluetun-proxy/secret-generator.yaml
@@ -1,0 +1,10 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: gluetun-proxy-secret-generator
+  annotations:
+    config.kubernetes.io/function: |
+      exec:
+        path: ksops
+files:
+  - ./gluetun-proxy-secret.sops.yaml

--- a/kubernetes/apps/gluetun-proxy/gluetun-proxy/values.yaml
+++ b/kubernetes/apps/gluetun-proxy/gluetun-proxy/values.yaml
@@ -1,0 +1,93 @@
+defaultPodOptions:
+  automountServiceAccountToken: false
+  dnsConfig:
+    options:
+      - name: ndots
+        value: '1'
+
+controllers:
+  main:
+    annotations:
+      reloader.stakater.com/auto: 'true'
+    pod:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: 'OnRootMismatch'
+
+    containers:
+      gluetun:
+        image:
+          repository: ghcr.io/qdm12/gluetun
+          tag: v3.42.0
+        env:
+          VPN_SERVICE_PROVIDER: windscribe
+          VPN_TYPE: openvpn
+          SERVER_REGIONS: ${WINDSCRIBE_REGION}
+          FIREWALL: 'on'
+          HTTPPROXY: 'on'
+          HTTPPROXY_LISTENING_ADDRESS: ':8888'
+          HTTPPROXY_STEALTH: 'on'
+          HTTPPROXY_LOGIN: '${HTTPPROXY_USER}'
+          HTTPPROXY_PASSWORD: '${HTTPPROXY_PASSWORD}'
+        envFrom:
+          - secretRef:
+              name: gluetun-proxy-secret
+        securityContext:
+          capabilities:
+            add:
+              - NET_ADMIN
+
+  ip-rotator:
+    type: cronjob
+    cronjob:
+      schedule: "0 * * * *"
+      successfulJobsHistory: 1
+      failedJobsHistory: 1
+    containers:
+      rotate:
+        image: ghcr.io/curlimages/curl:8.5.0
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            echo "Rotating IP..."
+            curl -s -X PUT http://gluetun-proxy-main:8000/v1/openvpn/status -H "Content-Type: application/json" -d '{"status":"stopped"}'
+            sleep 5
+            curl -s -X PUT http://gluetun-proxy-main:8000/v1/openvpn/status -H "Content-Type: application/json" -d '{"status":"running"}'
+            echo "IP rotation complete"
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            memory: 64Mi
+
+service:
+  gluetun:
+    controller: main
+    ports:
+      http:
+        port: 8888
+
+ingress:
+  gluetun:
+    enabled: true
+    className: internal
+    hosts:
+      - host: gluetun-proxy.laboratory.casa
+        paths:
+          - path: /
+            service:
+              identifier: gluetun
+              port: http
+
+persistence:
+  config:
+    type: emptyDir

--- a/kubernetes/apps/gluetun-proxy/gluetun-proxy/values.yaml
+++ b/kubernetes/apps/gluetun-proxy/gluetun-proxy/values.yaml
@@ -3,34 +3,32 @@ defaultPodOptions:
   dnsConfig:
     options:
       - name: ndots
-        value: '1'
+        value: "1"
 
 controllers:
   main:
     annotations:
-      reloader.stakater.com/auto: 'true'
+      reloader.stakater.com/auto: "true"
     pod:
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
         fsGroup: 1000
-        fsGroupChangePolicy: 'OnRootMismatch'
+        fsGroupChangePolicy: "OnRootMismatch"
 
     containers:
       gluetun:
         image:
           repository: ghcr.io/qdm12/gluetun
-          tag: v3.42.0
+          tag: v3.41.0@sha256:6b54856716d0de56e5bb00a77029b0adea57284cf5a466f23aad5979257d3045
         env:
           VPN_SERVICE_PROVIDER: windscribe
           VPN_TYPE: openvpn
-          SERVER_REGIONS: ${WINDSCRIBE_REGION}
-          FIREWALL: 'on'
-          HTTPPROXY: 'on'
-          HTTPPROXY_LISTENING_ADDRESS: ':8888'
-          HTTPPROXY_STEALTH: 'on'
-          HTTPPROXY_LOGIN: '${HTTPPROXY_USER}'
-          HTTPPROXY_PASSWORD: '${HTTPPROXY_PASSWORD}'
+          FIREWALL: "on"
+          HTTPPROXY: "on"
+          HTTPPROXY_LISTENING_ADDRESS: ":8888"
+          HTTPPROXY_STEALTH: "on"
+          SERVER_REGIONS: US Central, US East, US West
         envFrom:
           - secretRef:
               name: gluetun-proxy-secret
@@ -42,19 +40,21 @@ controllers:
   ip-rotator:
     type: cronjob
     cronjob:
-      schedule: "0 * * * *"
+      schedule: "15 * * * *"
       successfulJobsHistory: 1
       failedJobsHistory: 1
     containers:
       rotate:
-        image: ghcr.io/curlimages/curl:8.5.0
+        image:
+          repository: curlimages/curl
+          tag: 8.18.0@sha256:d94d07ba9e7d6de898b6d96c1a072f6f8266c687af78a74f380087a0addf5d17
         command: ["/bin/sh", "-c"]
         args:
           - |
             echo "Rotating IP..."
-            curl -s -X PUT http://gluetun-proxy-main:8000/v1/openvpn/status -H "Content-Type: application/json" -d '{"status":"stopped"}'
+            curl -s -X PUT http://gluetun-proxy-main:8000/v1/vpn/status -H "Content-Type: application/json" -d '{"status":"stopped"}'
             sleep 5
-            curl -s -X PUT http://gluetun-proxy-main:8000/v1/openvpn/status -H "Content-Type: application/json" -d '{"status":"running"}'
+            curl -s -X PUT http://gluetun-proxy-main:8000/v1/vpn/status -H "Content-Type: application/json" -d '{"status":"running"}'
             echo "IP rotation complete"
         securityContext:
           runAsUser: 1000

--- a/kubernetes/argo/apps/changedetection/changedetection.yaml
+++ b/kubernetes/argo/apps/changedetection/changedetection.yaml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: changedetection
+  namespace: argo-system
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  project: kubernetes
+  sources:
+    - repoURL: https://github.com/mebezac/home-cluster.git
+      path: kubernetes/apps/changedetection/changedetection
+      targetRevision: main
+      ref: changedetection-repo
+    - repoURL: ghcr.io/bjw-s-labs/helm
+      chart: app-template
+      targetRevision: 4.6.2
+      helm:
+        releaseName: changedetection
+        valueFiles:
+          - $changedetection-repo/kubernetes/apps/changedetection/changedetection/values.yaml
+  destination:
+    name: in-cluster
+    namespace: changedetection
+  syncPolicy:
+    automated:
+      allowEmpty: true
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/kubernetes/argo/apps/gluetun-proxy/gluetun-proxy.yaml
+++ b/kubernetes/argo/apps/gluetun-proxy/gluetun-proxy.yaml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: gluetun-proxy
+  namespace: argo-system
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  project: kubernetes
+  sources:
+    - repoURL: https://github.com/mebezac/home-cluster.git
+      path: kubernetes/apps/gluetun-proxy/gluetun-proxy
+      targetRevision: main
+      ref: gluetun-proxy-repo
+    - repoURL: ghcr.io/bjw-s-labs/helm
+      chart: app-template
+      targetRevision: 4.6.2
+      helm:
+        releaseName: gluetun-proxy
+        valueFiles:
+          - $gluetun-proxy-repo/kubernetes/apps/gluetun-proxy/gluetun-proxy/values.yaml
+  destination:
+    name: in-cluster
+    namespace: gluetun-proxy
+  syncPolicy:
+    automated:
+      allowEmpty: true
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
## Summary
- Add changedetection app translated from Flux to Argo CD
- Add gluetun-proxy app with Windscribe VPN and hourly IP rotation
- Move translate-flux-to-argo.md to .agents/workflows/
- Add AGENTS.md with reference to translation guide