### PR TITLE
Update opencode-manager image tag to pr-60-baseline

### DIFF
--- a/kubernetes/apps/opencode-manager/opencode-manager/values.yaml
+++ b/kubernetes/apps/opencode-manager/opencode-manager/values.yaml
@@ -13,7 +13,7 @@ controllers:
       main:
         image:
           repository: ghcr.io/mebezac/opencode-manager
-          tag: 0.9.0-baseline
+          tag: pr-60-baseline
         env:
           NODE_ENV: production
           HOST: 0.0.0.0


### PR DESCRIPTION
## Changes
- Updated opencode-manager image tag from `0.9.0-baseline` to `pr-60-baseline`

## Details
- Removed SHA digest tag for easier rolling updates
- Target branch: pr-60 development version