### PR TITLE
feat(apps): add podcast-adblock application

### DIFF
--- a/kubernetes/apps/podcasts/podcast-adblock/kustomization.yaml
+++ b/kubernetes/apps/podcasts/podcast-adblock/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generators:
+  - secret-generator.yaml

--- a/kubernetes/apps/podcasts/podcast-adblock/podcast-adblock-secret.sops.yaml
+++ b/kubernetes/apps/podcasts/podcast-adblock/podcast-adblock-secret.sops.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: podcast-adblock-secret
+  namespace: podcasts
+type: Opaque
+stringData:
+  # Add your secrets here, then encrypt with sops
+  # Example: API_KEY: your-api-key

--- a/kubernetes/apps/podcasts/podcast-adblock/podcast-adblock-secret.sops.yaml
+++ b/kubernetes/apps/podcasts/podcast-adblock/podcast-adblock-secret.sops.yaml
@@ -5,5 +5,27 @@ metadata:
   namespace: podcasts
 type: Opaque
 stringData:
-  # Add your secrets here, then encrypt with sops
-  # Example: API_KEY: your-api-key
+  REQUIRE_AUTH: ENC[AES256_GCM,data:ipmCTQ==,iv:f2apXbXu0/LDRmoqqvswZdLg4eVXcDSOhoorcD5lx0g=,tag:keLN9mGSnPJ10D1a4UekbA==,type:str]
+  PODLY_ADMIN_USERNAME: ENC[AES256_GCM,data:fgrM,iv:MiweJBFgaRf2V5HwEd61mMnJJ/tRY/SeSKs6XgWvS8A=,tag:yVMwQ3V1LmmxsunWC9s8fQ==,type:str]
+  PODLY_ADMIN_PASSWORD: ENC[AES256_GCM,data:GcgyK1poY2J50YmfPr7/MA3Kx30auKiSpg==,iv:6wj8MtIgZ9JtGSjsn9wG1mVvxWTIl6XretwmpHQb5/c=,tag:W2V+cyN0XP2Ov8fc7jYQzw==,type:str]
+  PODLY_SECRET_KEY: ENC[AES256_GCM,data:f2vUDpfKZAVDMmqN+I6+596iKR4FZRuPyRXKlMQYS+sUM1Xdwp6oXrwoMxndn+MUjn87KlxcpKMC3VIylVY31A==,iv:jJNyv8XOPxXg6vGAk4hYBu5CIGnr8pkSjZpOzaMicNc=,tag:oO78OdvPi/eqkh56PO/6+w==,type:str]
+  GROQ_API_KEY: ENC[AES256_GCM,data:lksptiut8NBOppvPXs1Dg5Eu38Fs24g1RC81iKifXfS2obF/wzZ4G1AlwPHCsqdk29RgIllYUYU=,iv:PfBFLcYBvHbaZfjRx1POHLKvHkPXIPO8didAe6aFt+s=,tag:mLcXw9+kSnIaGFyqhU14OQ==,type:str]
+  LLM_API_KEY: ENC[AES256_GCM,data:tqaPAVzoJ5tNZGRZgYsZr+ficBdjyFXROtmwyKOEohLfyr5AY2001n0qDN7RTqbhj5P0s2L/VbqGNp6Y4dTsfpNibbf5XI/0eQ==,iv:bTo/muCwP/jn8TYBgJG3ozGVXGAyYzcQWKIc0yyjNqw=,tag:un8Ee8XYEyigDy5xwSCaAA==,type:str]
+  LLM_MODEL: ENC[AES256_GCM,data:ZXHGPOU25rde/vaJD0W9mZl4JyXB7wHqfiZjp+TQI/0+JTCaG9z2CB6UhnI6,iv:CZ2L9g9rfBs7zmMBbcM9t/pdmRPnNGPq3E7cWkVUhz4=,tag:9Pug6eb+wnlISuUKBqp3Ww==,type:str]
+  OPENAI_BASE_URL: ENC[AES256_GCM,data:8eS8eYzxlki5y6i3RY5pekGf8o2Nmiu6lkHuVg==,iv:C1/hYCAckM8HaL1FK6IdbcqWKLOWL/neCv9G9Zk1/BU=,tag:Epnlx2tQLZEsin2tnyMLGw==,type:str]
+sops:
+  age:
+    - recipient: age1j7x3jkw82w02taqj8dmqplae07fxcrup2enejnta9z2v82fzsakqd4ka6p
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEbllPSG5rODJQVnNNWVRj
+        QjdqTlRYTEpINTBsR3BmdkJZYkFJejI3QWowCkxYaEQrdXAxdHRxd3FaZE1EeVZj
+        alZWZW9TeUVHQWxkK3pCNTA2bGk3Yk0KLS0tIGV3cGswcE5pVG1xaWNBZHNuckZH
+        K0JKYUQwdnJGMFhnQWRHMGxiR0pkbkEKIXwx7uNvzhSGw9OIZhcrp7MFozUG7473
+        w0y/QXwHcbU87Axhbqlri4S50c9phhOkgxXtA48MxS6Y88iXLMbONQ==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-02-01T03:41:29Z"
+  mac: ENC[AES256_GCM,data:eex8KstekZEw9nroRfoE+BJ9fvNIHqYcO88W88F/kgrJX1/htgWz+HfaLFRwCqSL2ImO7B6ksxd1jtoDYAKtABMxSY/c5AJFlBXSGjdcN+P9GFL755lnh9e5T44s/WfH67eU3V8dT3L2r9CgPHyAUg/g5KeF5B5f+SOTqyVcRTc=,iv:opaVIKqJtLItricTEbGpqZcCb13YKjUyfUEzBBlRMVo=,tag:xEP6JW4InGOt0sehB2QstA==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  mac_only_encrypted: true
+  version: 3.11.0

--- a/kubernetes/apps/podcasts/podcast-adblock/secret-generator.yaml
+++ b/kubernetes/apps/podcasts/podcast-adblock/secret-generator.yaml
@@ -1,0 +1,10 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: podcast-adblock-secret-generator
+  annotations:
+    config.kubernetes.io/function: |
+      exec:
+        path: ksops
+files:
+  - ./podcast-adblock-secret.sops.yaml

--- a/kubernetes/apps/podcasts/podcast-adblock/values.yaml
+++ b/kubernetes/apps/podcasts/podcast-adblock/values.yaml
@@ -1,0 +1,97 @@
+---
+defaultPodOptions:
+  securityContext:
+    runAsUser: 3000
+    runAsGroup: 3000
+    fsGroup: 3000
+    fsGroupChangePolicy: "OnRootMismatch"
+
+controllers:
+  main:
+    annotations:
+      reloader.stakater.com/auto: "true"
+    replicas: 1
+    containers:
+      main:
+        image:
+          repository: ghcr.io/mebezac/podcast-adblock
+          tag: 2.5.2
+          pullPolicy: IfNotPresent
+        resources:
+          requests:
+            cpu: 100m
+            memory: 2Gi
+          limits:
+            cpu: 3000m
+            memory: 8Gi
+        env:
+          PUID: "3000"
+          PGID: "3000"
+          CUDA_VISIBLE_DEVICES: "-1"
+          SERVER_THREADS: "3"
+          GROQ_WHISPER_MODEL: whisper-large-v3-turbo
+          GROQ_MAX_RETRIES: "3"
+          WHISPER_TYPE: groq
+        envFrom:
+          - secretRef:
+              name: podcast-adblock-secret
+        probes:
+          liveness: &probes
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /
+                port: 5001
+              initialDelaySeconds: 10
+              periodSeconds: 30
+              timeoutSeconds: 10
+              failureThreshold: 3
+          readiness: *probes
+          startup:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /
+                port: 5001
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              timeoutSeconds: 10
+              failureThreshold: 30
+
+service:
+  main:
+    controller: main
+    ports:
+      http:
+        port: 5001
+
+ingress:
+  main:
+    enabled: true
+    className: external
+    annotations:
+      external-dns.alpha.kubernetes.io/target: external.laboratory.casa
+    hosts:
+      - host: pcab.laboratory.casa
+        paths:
+          - path: /
+            pathType: Prefix
+            service:
+              identifier: main
+              port: http
+
+persistence:
+  data:
+    enabled: true
+    type: persistentVolumeClaim
+    storageClass: longhorn-single-replica
+    accessMode: ReadWriteOnce
+    size: 10Gi
+    globalMounts:
+      - path: /app/src/instance
+  cache:
+    type: emptyDir
+    globalMounts:
+      - path: /.cache

--- a/kubernetes/argo/apps/podcasts/podcast-adblock.yaml
+++ b/kubernetes/argo/apps/podcasts/podcast-adblock.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: podcast-adblock
+  namespace: argo-system
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  project: kubernetes
+  sources:
+    - repoURL: https://github.com/mebezac/home-cluster.git
+      path: kubernetes/apps/podcasts/podcast-adblock
+      targetRevision: main
+      ref: podcast-adblock-repo
+    - repoURL: ghcr.io/bjw-s-labs/helm
+      chart: app-template
+      targetRevision: 4.6.2
+      helm:
+        releaseName: podcast-adblock
+        valueFiles:
+          - $podcast-adblock-repo/kubernetes/apps/podcasts/podcast-adblock/values.yaml
+  destination:
+    name: in-cluster
+    namespace: podcasts
+  syncPolicy:
+    automated:
+      allowEmpty: true
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
## Summary

Add podcast-adblock application to the podcasts namespace.

## Changes

- **New Application:** `podcast-adblock` in `kubernetes/apps/podcasts/podcast-adblock/`
- **Image:** `ghcr.io/mebezac/podcast-adblock:2.5.2`
- **Ingress:** `pcab.laboratory.casa` (external class)
- **Configuration:** Based on `podly-pure-podcasts` with identical:
  - Environment variables (GROQ_WHISPER_MODEL, WHISPER_TYPE, SERVER_THREADS, etc.)
  - Resource requests/limits (100m-3000m CPU, 2Gi-8Gi memory)
  - Storage (10Gi PVC with longhorn-single-replica)
  - Security context (UID/GID 3000)
  - Health probes

## Files Added

- `kubernetes/apps/podcasts/podcast-adblock/values.yaml`
- `kubernetes/apps/podcasts/podcast-adblock/kustomization.yaml`
- `kubernetes/apps/podcasts/podcast-adblock/secret-generator.yaml`
- `kubernetes/apps/podcasts/podcast-adblock/podcast-adblock-secret.sops.yaml`
- `kubernetes/argo/apps/podcasts/podcast-adblock.yaml`

## Notes

- Secrets template provided at `podcast-adblock-secret.sops.yaml` (to be encrypted with SOPS)
- Argo CD Application configured with sync-wave "0"
- Follows existing GitOps workflow patterns in the repository