### PR TITLE
talos: migrate T2 Mac minis to custom v1.13.5 installer + k8s v1.36.2 sync

### DIFF
--- a/.claude/skills/talos-upgrade/SKILL.md
+++ b/.claude/skills/talos-upgrade/SKILL.md
@@ -1,0 +1,316 @@
+---
+name: talos-upgrade
+description: >-
+  Upgrade the Talos version on this home-cluster's nodes safely, one at a time,
+  draining Longhorn + workloads first and verifying full health before moving on.
+  Use whenever the user wants to bump Talos (e.g. "get the cluster on v1.13.5",
+  "upgrade talos", "roll out the new talos version", "update <node> to <version>",
+  "do the talos nodes"), reinstall/recover a node, or migrate a node onto the
+  custom Mac installer. Handles the whole node loop: pick a safe order
+  (workers → control-plane, non-leaders → etcd-leader last), cordon, drain past
+  the Longhorn instance-manager PDB, evacuate single-replica volumes that would
+  otherwise go offline, run `talosctl upgrade --preserve`, ride out the T2 Mac
+  BootFFFF non-fatal error, re-enable scheduling, and confirm every volume /
+  pod / etcd member is healthy before the next node. Knows this repo's talhelper
+  layout, the custom GCC installer for the talmac nodes, and the Longhorn
+  gotchas (stale USB mounts, diskUUID mismatch, data-locality PVs, CNPG
+  switchover). Reach for this any time a Talos node needs upgrading, reinstalling,
+  or migrating.
+---
+
+# Talos node upgrade (safe, one node at a time)
+
+Upgrade Talos on cluster nodes so **nothing loses data and no volume goes
+unavailable unexpectedly**. The loop for every node: evacuate → `talosctl
+upgrade --preserve` → verify → restore → confirm cluster fully healthy → only
+then touch the next node. Never two nodes at once.
+
+**This is the bootstrap/Talos layer — ArgoCD does NOT manage it.** Config lives
+in `kubernetes/bootstrap/talos/` (talhelper), applied manually. Config edits are
+committed to the repo normally (no attribution trailer per repo convention).
+
+## Setup (run first, every session)
+
+```bash
+cd kubernetes/bootstrap/talos
+export SOPS_AGE_KEY_FILE=/Users/zac/projects/lab_casa/home-cluster/age.key
+export TALOSCONFIG="$PWD/clusterconfig/talosconfig"
+# regenerate configs so the install image reflects the target talosVersion:
+talhelper genconfig --config-file talconfig.yaml --secret-file talsecret.sops.yaml --out-dir clusterconfig
+```
+
+`talconfig.yaml` already carries `talosVersion:` — the version everything targets.
+To upgrade the whole cluster to a new patch, bump `talosVersion` there first (and
+`kubernetesVersion` if desired), regen, then loop. For a same-version rollout
+(nodes lagging the pinned version) no edit is needed — just loop.
+
+### Node inventory & upgrade image
+
+Each node's upgrade image = its **install image** from the generated config
+(factory schematic + `:version`, or the custom installer for talmacs):
+
+```bash
+for f in clusterconfig/kubernetes-*.yaml; do
+  echo "$f -> $(grep -A3 'install:' "$f" | grep image: | head -1 | awk '{print $2}')"
+done
+```
+
+Current nodes (verify live, don't trust this list blindly):
+
+| Node | IP | Role | Longhorn? | Installer |
+|-|-|-|-|-|
+| elitebook-01 | 10.25.30.45 | control-plane | no | factory `249d9135…` |
+| elitebook-02 | 10.25.30.46 | control-plane | no | factory `249d9135…` |
+| wyse-5070-03 | 10.25.30.35 | control-plane | no | factory `9ba0b24a…` |
+| wyse-5070-01 | 10.25.30.33 | worker | yes | factory `9ba0b24a…` |
+| wyse-5070-02 | 10.25.30.34 | worker | yes | factory `9ba0b24a…` |
+| talmac-01 | 10.25.30.42 | worker | yes | **`ghcr.io/mebezac/talos-mac/installer`** |
+| talmac-02 | 10.25.30.43 | worker | yes | **custom** |
+| talmac-03 | 10.25.30.44 | worker | yes | **custom** |
+
+The **talmac** nodes are 2018 T2 Intel Macs and MUST use the custom GCC-linked
+installer (`ghcr.io/mebezac/talos-mac/installer:<ver>`) — stock Talos 1.13+ hangs
+at cold boot (siderolabs/talos#13579). Never point a talmac at `factory.talos.dev`
+for 1.13+. See the `talos-mac-installer` sibling repo + the memory of the same name.
+
+## Choose the order
+
+1. **Workers first, control-plane last.** Workers are lower-risk; get the
+   procedure warm on them.
+2. **Control-plane: non-leaders first, the etcd leader LAST.** Find the leader:
+   ```bash
+   talosctl -e 10.25.30.45 -n 10.25.30.45,10.25.30.46,10.25.30.35 etcd status
+   # LEADER column shows the member ID that is leader; upgrade that node last.
+   ```
+   With 3 CP nodes, quorum is 2 — rebooting one keeps the cluster up. Verify all
+   3 etcd members are healthy & converged **before each** CP node and again after.
+3. Do talmacs whenever; they're workers. In-place upgrade works (they don't need
+   the USB unless already bricked on a non-booting stock 1.13.x — see "Mac notes").
+
+## The per-node loop
+
+For each node, `N=<ip>` and `H=<hostname>`.
+
+### 1. Baseline + pick the endpoint
+
+```bash
+# all volumes healthy before we start? (must be — don't upgrade onto a degraded cluster)
+kubectl -n longhorn-system get volumes.longhorn.io -o json | python3 -c "
+import sys,json;d=json.load(sys.stdin)
+bad=[v['metadata']['name'] for v in d['items'] if v['status'].get('robustness') in ('degraded','faulted')]
+print('degraded/faulted:', bad or '(none)')"
+```
+
+**When the node you're upgrading is also a talosctl endpoint** (the 3 CP IPs are
+endpoints), drive its `talosctl` calls through a *different* endpoint with `-e`
+(e.g. upgrade `.46` via `-e 10.25.30.45`), or the command dies mid-reboot.
+
+### 2. Longhorn: analyse redundancy, then evacuate correctly
+
+Only relevant for Longhorn nodes (wyse-01/02, talmacs). **The critical question:
+does this node hold the LAST healthy replica of any volume?** If yes, a reboot
+takes that volume offline — you must move the replica off first.
+
+```bash
+kubectl -n longhorn-system get replicas.longhorn.io -o json | python3 -c "
+import sys,json
+d=json.load(sys.stdin); NODE='$H'
+from collections import defaultdict
+by=defaultdict(list)
+for r in d['items']:
+    if r['spec']['volumeName'] in {x['spec']['volumeName'] for x in d['items'] if x['spec'].get('nodeID')==NODE}:
+        by[r['spec']['volumeName']].append((r['spec'].get('nodeID'),r.get('status',{}).get('currentState'),r['spec'].get('healthyAt','')!=''))
+lastonly=[]
+for vn,reps in by.items():
+    he=sum(1 for n,st,h in reps if n!=NODE and h and st=='running')
+    if any(n==NODE for n,_,_ in reps) and he==0: lastonly.append(vn)
+print('volumes whose LAST healthy replica is on',NODE,':', lastonly or 'NONE')"
+```
+
+- **NONE (all volumes redundant elsewhere)** → `--preserve` is safe. Disable
+  scheduling *without* eviction (keeps the local replicas; they reattach after
+  reboot, much faster than a rebuild):
+  ```bash
+  kubectl cordon $H
+  kubectl -n longhorn-system patch nodes.longhorn.io $H --type=merge \
+    -p '{"spec":{"allowScheduling":false,"evictionRequested":false}}'
+  ```
+- **Some volumes have their last replica here** (typically single-replica
+  volumes: numberOfReplicas=1, or data-locality-pinned) → you MUST evacuate them
+  or they go offline during the reboot. Request full node eviction and wait for
+  **0 replicas** before upgrading:
+  ```bash
+  kubectl cordon $H
+  kubectl -n longhorn-system patch nodes.longhorn.io $H --type=merge \
+    -p '{"spec":{"allowScheduling":false,"evictionRequested":true}}'
+  # wait until 0 replicas remain on the node (Longhorn rebuilds them elsewhere):
+  until [ "$(kubectl -n longhorn-system get replicas.longhorn.io -o json | python3 -c "
+  import sys,json;print(sum(1 for r in json.load(sys.stdin)['items'] if r['spec'].get('nodeID')=='$H'))")" = 0 ]; do sleep 6; done
+  ```
+  **Remember to set `evictionRequested:false` again after the node is back**, or
+  Longhorn keeps refusing to schedule replicas there.
+
+Identify what the single-replica volumes actually are so you know the blast radius:
+```bash
+kubectl get pv -o json | python3 -c "
+import sys,json
+for p in json.load(sys.stdin)['items']:
+    c=p['spec'].get('claimRef',{}); print(p['metadata']['name'][:20],'->',c.get('namespace'),'/',c.get('name'))"
+```
+Common ones on this cluster: observability (victoria-logs/metrics/alertmanager),
+and CNPG postgres instances (single Longhorn replica each — CNPG does its own
+app-level HA across instances).
+
+### 3. Drain
+
+```bash
+kubectl drain $H --ignore-daemonsets --delete-emptydir-data --timeout=15m
+```
+Run it **backgrounded** (drains exceed the 2-min foreground cap). Expected residue:
+- **Static control-plane pods** (`kube-apiserver/controller-manager/scheduler-<node>`)
+  never drain — that's fine, they cycle with the node.
+- **Longhorn `instance-manager-…`** may block on its PDB
+  (`node-drain-policy: block-if-contains-last-replica`) while replicas are still
+  running. If you evacuated to 0 replicas in step 2, the PDB clears and drain
+  finishes. If you used `--preserve`, the instance-manager stays blocked until the
+  volumes detach (workloads evicted) — that's OK, the upgrade's own reboot handles
+  it; you can stop waiting on the drain once all *real* workloads are off.
+- **CNPG**: draining the node running the **primary** triggers an automatic clean
+  switchover to another instance (a few seconds' write blip). Confirm:
+  `kubectl -n database get cluster <name> -o jsonpath='{.status.currentPrimary}'`.
+- **Data-locality PVs** (e.g. jellyfin) node-pin their pod — the pod goes
+  `Pending` until this node returns. Expected; it reschedules post-upgrade.
+
+### 4. Upgrade — `--preserve`, backgrounded, never timeout-wrapped
+
+```bash
+talosctl -e <other-endpoint-or-$N> -n $N upgrade \
+  --image <install-image-from-step-'Node inventory'>:<version> --preserve
+```
+**Never wrap `talosctl upgrade` (or `reset`) in `timeout`** — an interrupted
+upgrade leaves the node in a half-reset LOCKED state. Background it and poll.
+
+`--preserve` keeps EPHEMERAL/etcd data across the reboot. Talos cordons/drains,
+reboots into the new UKI, then auto-uncordons the k8s node itself.
+
+### 5. Wait for it back, then verify
+
+```bash
+until talosctl -e <endpoint> -n $N version 2>/dev/null | grep -A1 Server | grep -q <version>; do sleep 6; done
+talosctl -e <endpoint> -n $N version | grep -A2 Server | grep Tag   # <version>
+kubectl get node $H -o wide                                         # Ready, Talos (<version>), kernel 6.18.x
+```
+
+**Control-plane extra check — etcd must be fully healthy before the next CP:**
+```bash
+talosctl -e 10.25.30.45 -n 10.25.30.45,10.25.30.46,10.25.30.35 etcd status
+# 3 members, no LEARNER, ERRORS column empty, RAFT INDEX within a few of each other, same TERM
+talosctl -e 10.25.30.45 -n 10.25.30.45 etcd members   # 3 members, LEARNER=false
+kubectl -n kube-system get pods --field-selector spec.nodeName=$H | grep -E 'apiserver|controller|scheduler'  # 1/1
+```
+(Mixed etcd patch versions across members mid-rollout is fine; a leader
+re-election when you upgrade the leader is expected — TERM bumps by 1.)
+
+### 6. Restore Longhorn scheduling (Longhorn nodes only)
+
+```bash
+kubectl -n longhorn-system patch nodes.longhorn.io $H --type=merge \
+  -p '{"spec":{"allowScheduling":true,"evictionRequested":false}}'   # evictionRequested:false is mandatory if you evicted in step 2
+kubectl -n longhorn-system get nodes.longhorn.io $H -o json | python3 -c "
+import sys,json;d=json.load(sys.stdin)
+for n,st in d['status']['diskStatus'].items():
+    print(n,{c['type']:c['status'] for c in st.get('conditions',[])})"   # Ready:True Schedulable:True
+```
+Talos already uncordoned the k8s node. If you manually `kubectl cordon`'d and it
+didn't auto-uncordon, `kubectl uncordon $H`.
+
+### 7. Confirm cluster fully healthy — GATE before the next node
+
+Do NOT start the next node until all of these pass:
+```bash
+# all volumes healthy (detached volumes show robustness=unknown — that's fine, not degraded/faulted)
+kubectl -n longhorn-system get volumes.longhorn.io -o json | python3 -c "
+import sys,json;d=json.load(sys.stdin)
+from collections import Counter
+print(dict(Counter(v['status'].get('robustness') for v in d['items'])))
+print('degraded/faulted:',[v['metadata']['name'] for v in d['items'] if v['status'].get('robustness') in ('degraded','faulted')] or '(none)')"
+# zero non-ready pods
+kubectl get pods -A -o json | python3 -c "
+import sys,json;d=json.load(sys.stdin)
+bad=[(p['metadata']['namespace'],p['metadata']['name']) for p in d['items']
+     if p['status']['phase'] not in ('Running','Succeeded')
+     or (p['status']['phase']=='Running' and not any(c['type']=='Ready' and c['status']=='True' for c in p['status'].get('conditions',[])))]
+print('non-ready:',len(bad)); [print(' ',*b) for b in bad[:20]]"
+```
+Wait for replica rebuilds to finish (evacuated volumes rebuild back onto the node
+once scheduling is restored). Only when volumes are all healthy and pods all ready
+do you move on.
+
+## Mac (talmac) notes
+
+- **The BootFFFF "failure" is cosmetic.** In-place upgrade of a talmac reports
+  `failed to create boot entry: BootFFFF: declared length of FilePath … overruns
+  available data` and exits 1 — Apple's EFI NVRAM has a malformed variable Talos
+  can't parse. The new UKI IS written and systemd-boot boots it. Always re-check
+  `talosctl -n $N version` → it upgraded despite the error.
+- **USB ISO reinstall is only for a talmac already bricked** on a non-booting
+  stock 1.13.x. Flash `metal-amd64.iso` from the matching
+  `mebezac/talos-mac-installer` GitHub release, boot holding ⌥ → EFI Boot,
+  `talosctl apply-config --insecure`. A normal migration off a working version is
+  just an in-place `upgrade --preserve`.
+- **Stale USB Longhorn mount after replug.** If a USB enclosure was unplugged and
+  replugged, the old bind mount goes stale (`/var/mnt/longhorn-usb` → dead
+  `/dev/sda1`, `input/output error` on `longhorn-disk.cfg`, disk `Ready:False`).
+  The upgrade's **reboot fixes it** — Talos re-resolves the `by-id` mount and
+  Longhorn re-adopts automatically **if the on-disk diskUUID still matches** the
+  node CR. No manual dance needed for that case.
+- **Longhorn diskUUID mismatch** ("record diskUUID doesn't match the one on the
+  disk"): happens when `/var/lib/longhorn/` got reset (fresh install, or a
+  `--preserve` upgrade that reset EPHEMERAL) so the on-disk cfg has a *new* UUID.
+  Fix only if the disk holds **0 replicas** (check first!). The webhook blocks a
+  plain remove — you must **disable, remove, re-add**, one disk at a time:
+  ```bash
+  kubectl -n longhorn-system patch nodes.longhorn.io $H --type=json \
+    -p '[{"op":"replace","path":"/spec/disks/<disk-name>/allowScheduling","value":false}]'
+  kubectl -n longhorn-system patch nodes.longhorn.io $H --type=json \
+    -p '[{"op":"remove","path":"/spec/disks/<disk-name>"}]'
+  # wait for it to leave status.diskStatus, then re-add with the SAME spec
+  # (path, storageReserved, tags — copy from a healthy peer node like talmac-03):
+  kubectl -n longhorn-system patch nodes.longhorn.io $H --type=json \
+    -p '[{"op":"add","path":"/spec/disks/<disk-name>","value":{"allowScheduling":true,"diskDriver":"","diskType":"filesystem","evictionRequested":false,"path":"/var/lib/longhorn/","storageReserved":32212254720,"tags":[]}}]'
+  # Longhorn adopts the on-disk UUID → Ready:True Schedulable:True
+  ```
+  Removing/re-adding a shared Longhorn disk CR is a shared-cluster mutation — the
+  auto-approver will ask for explicit user confirmation. Get it before running.
+
+## Repo cleanup after migrating a node onto a new installer
+
+If you moved a node onto the custom installer or off a version pin, edit
+`talconfig.yaml` (set its `talosImageURL`, delete its
+`patches/<node>/machine-install.yaml` pin + the reference line), keep
+`machine-disks.yaml`, `talhelper genconfig` to confirm the install image resolved,
+update `docs/talmac-1.13-upgrade.md`, and commit (conventional-commit message, no
+attribution trailer).
+
+## Gotchas learned (quick reference)
+
+- **One node at a time. Always.** Gate on full cluster health between nodes.
+- **Single-replica / last-replica-on-node volumes must be evicted, not just
+  `--preserve`d** — otherwise they go offline during the reboot. Analyse
+  redundancy first (step 2).
+- **Longhorn instance-manager PDB blocks drain** while replicas run; `block-if-
+  contains-last-replica` allows it once volumes are redundant/detached. Evacuating
+  to 0 replicas is the deterministic unblock.
+- **`evictionRequested:true` must be reset to `false`** after the node returns.
+- **Never `timeout`-wrap `talosctl upgrade`/`reset`.** Background it. A killed
+  upgrade LOCKS the node.
+- **Detached volume `robustness=unknown` is normal** (no attached workload) — not
+  a fault. Only `degraded`/`faulted` are real problems.
+- **CNPG primary drain = automatic switchover.** Safe and expected.
+- **Talmac BootFFFF error is non-fatal.** Verify version, don't reinstall.
+- **etcd: leader last, verify 3 healthy converged members between CP nodes**, use
+  a different `-e` endpoint when the node being rebooted is itself an endpoint.
+- **factory DNS (node resolver 10.25.30.38) is flaky** — a failed image pull is a
+  safe no-op, just retry. First boot after an install can log a burst of DNS/NTP
+  timeouts and look stalled for 1-2 min, then self-recovers; don't reinstall.
+- **This layer isn't ArgoCD-managed** — talhelper/bootstrap, applied by hand.

--- a/kubernetes/bootstrap/talos/docs/talmac-1.13-upgrade.md
+++ b/kubernetes/bootstrap/talos/docs/talmac-1.13-upgrade.md
@@ -1,342 +1,129 @@
-# Runbook: Migrating an Intel Mac mini node onto Talos v1.13.x
+# Recovering / upgrading a talmac node to Talos v1.13+ (T2 Intel Mac)
 
-Getting a `talmac-*` node (Intel `Macmini8,1`, 2018 T2) from its pinned **Talos
-v1.12.4** up to **v1.13.x** without hitting the Intel-Mac boot hang.
+## Background
 
-Worked example targets **talmac-02** (`10.25.30.43`); the procedure is parameterized
-(`$N` / `$H`) so it also applies to talmac-01 (`10.25.30.42`) and talmac-03
-(`10.25.30.44`). Do one node at a time.
+Stock Talos v1.13 **hangs at cold boot** on the 2018 T2 Mac mini: its kernel uses a
+Clang+LLD EFI stub that Apple's Intel firmware refuses to hand off to
+(siderolabs/talos#13579). An in-place `talosctl upgrade` *appears* to work because it
+kexecs the new kernel — but the box never survives a real power cycle.
 
----
+**The earlier GRUB-ladder idea in this doc's history was wrong** (Talos GRUB 2.14 also
+uses EFI hand-off, so it hangs too). The working fix is a **custom installer** built
+with the kernel linked by GNU ld instead of LLD:
 
-## Why this is not a normal upgrade
+- Repo: `github.com/mebezac/talos-mac-installer` (builds via GitHub Actions on tag push)
+- Installer image: `ghcr.io/mebezac/talos-mac/installer:<talos-version>`
+- USB ISO: attached to the matching GitHub Release (`metal-amd64.iso`)
 
-Talos **v1.13.x hangs at the TALOS splash on Intel Macs**. Root cause: the v1.13
-kernel's Clang+LLD/ThinLTO EFI stub, which Apple's Intel EFI firmware cannot hand off
-to during a cold UEFI boot (siderolabs/talos#13579 — affects Ubuntu/Debian too, not
-Talos-specific).
+A GCC-linked kernel cold-boots fine under UKI/systemd-boot, so **no GRUB, no version
+ladder** — the Mac upgrades like any other node once it's on the custom image.
 
-The UKI/systemd-boot default landed in **Talos 1.10**. The talmacs were installed fresh
-at v1.12.4, so they boot via **UKI/sd-boot** (`bootedWithUKI: true`; partition layout
-`EFI/META/STATE/EPHEMERAL`, no BIOS/BOOT). **Talos upgrades preserve the existing
-bootloader**, so a UKI node upgraded in place to v1.13.x stays on UKI and hangs.
+`talconfig.yaml` already points **talmac-02** at `ghcr.io/mebezac/talos-mac/installer`
+(talhelper appends `:${talosVersion}`). talmac-01/03 remain on their v1.12.4 pins until
+migrated the same way.
 
-The fix: reinstall from **v1.9.6** — the last GRUB-defaulting release — then ladder the
-Talos version up one minor at a time. GRUB uses the legacy x86 boot protocol that boots
-fine on Mac firmware, and it is preserved across every upgrade, so it rides all the way
-to v1.13.x and dodges the hang.
+## Recover talmac-02 (10.25.30.43) — currently down on a non-booting stock v1.13.5
 
-### Kubernetes version — no cluster downgrade
-
-The cluster's k8s version is the **control-plane/API-server** version (1.35) and does
-not change. A worker only runs a **kubelet**, and the k8s skew policy (≥1.28) allows a
-kubelet up to **3 minors older** than the API server — so kubelet 1.32 (Talos 1.9.6's
-max) is fully supported against a 1.35 API server. Kubelet walks up with Talos, reaching
-1.35.6 at the end. Only this one worker runs an older kubelet, transiently.
-
----
-
-## Node facts (talmac-02, verified live)
-
-- IP `10.25.30.43`, hostname `talmac-02`.
-- **Two disks — know which is which before wiping anything:**
-
-  | Role | Device | Transport | Identity | Stable by-id |
-  |-|-|-|-|-|
-  | **OS / install** | `nvme0n1` | nvme | Apple SSD AP0256M, 251 GB | `nvme-APPLE_SSD_AP0256M_<serial>` |
-  | **Longhorn** | `sda` | **usb** | Intel 670p 1 TB in Sabrent enclosure | `usb-Sabrent_SSD_<serial>-0:0`, mounted `/var/mnt/longhorn-usb` |
-
-  The Longhorn NVMe bridges over **USB** (`sda`), not as a native NVMe — so the internal
-  Apple SSD is the **only** `nvme` device and `/dev/nvme0n1` is unambiguous. (If a talmac
-  ever shows the external disk as a real `nvme1n1`, the disk-by-id pin below becomes
-  mandatory, not just insurance.) Verify per node with `talosctl -n <ip> get disks` and
-  `talosctl -n <ip> get systemdisk` before touching disks.
-- Factory schematic `2385c7daef21b71bfd59f74b96cdccfebe5003bcef3cee5b56b1add17a8f4817`
-  = extensions `i915, intel-ucode, iscsi-tools, thunderbolt, util-linux-tools`
-  + kernel args `intel_iommu=on iommu=pt pcie_ports=compat`.
-  `pcie_ports=compat` is what makes the Apple NVMe usable — it must be present at every
-  step. Using the same schematic for every install/upgrade image keeps it consistent.
-
-## Tooling: talhelper + Taskfile (read before running commands)
-
-This repo drives Talos through **talhelper** wrapped in `.taskfiles/talos`. Normal ops:
-
-| Task | What it runs |
-|-|-|
-| `task talos:generate-config` | `talhelper genconfig` → `clusterconfig/` |
-| `task talos:apply-node IP=<ip>` | `talhelper gencommand apply --node <ip> --extra-flags '--mode=auto' \| bash` |
-| `task talos:upgrade-node IP=<ip>` | `talhelper gencommand upgrade` with `--image=factory.../<schematic>:<ver> --preserve` |
-| `task talos:upgrade-k8s` | `talhelper gencommand upgrade-k8s --to <ver>` |
-| `task talos:reset` | `talhelper gencommand reset --system-labels-to-wipe STATE,EPHEMERAL` |
-
-`TALOSCONFIG` = `clusterconfig/talosconfig`, secret file = `talsecret.sops.yaml`, config =
-`talconfig.yaml` — all exported by the root `Taskfile.yaml`. Run tasks from repo root; if
-you invoke `talosctl`/`talhelper` directly, `export TALOSCONFIG=$(pwd)/kubernetes/bootstrap/talos/clusterconfig/talosconfig` first.
-
-**This runbook deliberately deviates from those tasks in three spots — do not "simplify"
-them back to the tasks:**
-
-1. **`upgrade-node` / `upgrade-k8s` read the *global* `.talosVersion` / `.kubernetesVersion`**
-   (v1.13.5 / v1.35.6). Running them would jump straight to v1.13.5 and defeat the ladder.
-   The intermediate rungs therefore drive `talhelper gencommand ... --config-file /tmp/talconfig.step.yaml`
-   (a temp copy pinned to each rung) or raw `talosctl upgrade --image ...:<rung>`.
-2. **The repo's `reset` only wipes STATE+EPHEMERAL**, leaving the EFI/UKI partition — a Mac
-   could then re-boot the old install instead of the USB. Phase 2 uses full
-   `--system-disk-wipe-spec all` on purpose.
-3. **Maintenance-mode apply needs `--insecure`** (the `apply-node` task's preconditions
-   assume a live node with an issued cert). Phase 3 calls it explicitly.
-
-## Version ladder (sequential — do not skip minors)
-
-| Step | Talos | kubelet (worker) | Bootloader |
-|-|-|-|-|
-| Fresh install | v1.9.6 | v1.32.x | **GRUB** (last GRUB-default release) |
-| Upgrade 1 | v1.10.9 | v1.33.x | GRUB (preserved) |
-| Upgrade 2 | v1.11.6 | v1.34.x | GRUB (preserved) |
-| Upgrade 3 | v1.12.9 | v1.35.6 | GRUB (preserved) |
-| Upgrade 4 | v1.13.5 | v1.35.6 | GRUB (preserved) — **no hang** |
-
-Rule per rung: **upgrade Talos first, then bump kubelet** to that release's max
-(kubelet ≤ Talos-supported k8s max, and ≤ API server 1.35). Pick the newest patch of
-each k8s minor; check the target Talos release notes' supported-k8s range.
-
-All installer/upgrade images use the same schematic:
-`factory.talos.dev/installer/2385c7daef21b71bfd59f74b96cdccfebe5003bcef3cee5b56b1add17a8f4817:<version>`
-
----
-
-## Procedure
-
-### Phase 0 — Pre-flight & evacuate (graceful)
+Run from repo root unless noted. Env:
 
 ```bash
+export SOPS_AGE_KEY_FILE=/Users/zac/projects/lab_casa/home-cluster/age.key
 N=10.25.30.43 ; H=talmac-02
-talosctl -n $N version                            # expect Talos v1.12.4
-talosctl -n $N get securitystate | grep -i uki    # bootedWithUKI: true (why we reinstall)
-kubectl get node $H -o wide                        # note current kubelet
-
-# Cordon + stop Longhorn scheduling and request replica eviction off this node
-kubectl cordon $H
-kubectl -n longhorn-system patch nodes.longhorn.io $H --type=merge \
-  -p '{"spec":{"allowScheduling":false,"evictionRequested":true}}'
-
-# Wait until NO replicas remain on the node (rebuilt elsewhere), all volumes still Healthy
-watch "kubectl -n longhorn-system get replicas.longhorn.io -o wide | grep -c $H"   # -> 0
-
-# Drain workloads
-kubectl drain $H --ignore-daemonsets --delete-emptydir-data --timeout=15m
+cd kubernetes/bootstrap/talos
+export TALOSCONFIG="$PWD/clusterconfig/talosconfig"
 ```
 
-Step 2 covers replicas on both the internal NVMe and the USB Longhorn disk.
-
-### Phase 1 — Build the v1.9.6 GRUB USB
+### 1. Flash the custom ISO to USB (macOS)
 
 ```bash
-curl -LO "https://factory.talos.dev/image/2385c7daef21b71bfd59f74b96cdccfebe5003bcef3cee5b56b1add17a8f4817/v1.9.6/metal-amd64.iso"
-
-# Write to USB (macOS): identify, unmount, dd to the RAW device
-diskutil list
+gh release download v1.13.5 -R mebezac/talos-mac-installer -p 'metal-amd64.iso' -O /tmp/talmac.iso
+diskutil list                                   # find the USB, e.g. /dev/disk4
 diskutil unmountDisk /dev/diskN
-sudo dd if=metal-amd64.iso of=/dev/rdiskN bs=4m status=progress
+sudo dd if=/tmp/talmac.iso of=/dev/rdiskN bs=4m status=progress
 sync ; diskutil eject /dev/diskN
 ```
 
-T2 Startup Security (should already be set from the original install; verify if boot
-fails): **Reduced Security + Allow booting from external media** (recoveryOS → Startup
-Security Utility). Secure Boot stays off — the schematic is `secureboot: false`.
+### 2. Boot it — this is the real cold-boot test
 
-### Phase 2 — Wipe the UKI install & boot v1.9.6
+Power on holding **⌥ (Option)** → pick **EFI Boot**. T2 Startup Security must already
+allow external + reduced security (set during the original install; if it won't boot the
+USB, fix in recoveryOS → Startup Security Utility).
 
-> **Leave the Longhorn USB enclosure (`sda`) PLUGGED IN for the reset.** ⚠️ Learned the
-> hard way: `machine.disks` references the enclosure, and Talos reset's volume-teardown
-> phase **blocks/locks** (`sequence not started: locked`) if that disk is absent — the
-> reset fails. Keep it plugged through the reset; you unplug it later, in maintenance mode
-> (Phase 3), before the install. The reset only wipes the **system disk**, so the plugged
-> enclosure is never at risk here.
+- **Reaches Talos maintenance mode** → the GCC kernel cold-boots. The whole fix is proven.
+- **Folder-with-`?` / hang** → firmware still rejects it; stop and re-check the build,
+  don't proceed.
+
+Keep the **USB Longhorn enclosure plugged in** (machine-disks.yaml references it; Talos
+volume teardown blocks if a referenced disk is absent). Node comes up on its DHCP
+reservation `10.25.30.43` in maintenance mode.
+
+### 3. Install the custom image
 
 ```bash
-# Wipe ONLY the system disk (the internal Apple SSD) so the Mac can't boot back into the
-# old v1.12.4 UKI. --wipe-mode system-disk leaves ALL user disks (incl. the Longhorn sda)
-# untouched. Do NOT use --wipe-mode all or --user-disks-to-wipe.
-# ⚠️ Do NOT wrap this in `timeout` — the client abort signal interrupts the reset and
-#    leaves the node in a half-reset LOCKED state.
-talosctl -n $N reset --wipe-mode system-disk --reboot --graceful=false
+talhelper genconfig --config-file talconfig.yaml --secret-file talsecret.sops.yaml \
+  --out-dir clusterconfig
+# sanity: install image should be the custom installer, not factory.talos.dev
+grep -A2 'install:' clusterconfig/kubernetes-talmac-02.yaml | grep image   # ghcr.io/mebezac/...:v1.13.5
+
+talosctl apply-config --insecure -n $N --file clusterconfig/kubernetes-talmac-02.yaml
 ```
 
-Boot the USB: power on holding **Option (⌥)** (keep holding until the boot picker appears)
-→ pick **EFI Boot** (the USB icon; if two appear, either works). The node comes up in
-**maintenance mode** and DHCPs (the static `10.25.30.43` was wiped). Find its address
-(DHCP lease / console) and call it `$M`.
-
-### Phase 3 — Install v1.9.6 with kubelet 1.32 (via talhelper)
-
-> **Now unplug the Longhorn USB enclosure (`sda`)** — you're in maintenance mode, which
-> has no config referencing it, so nothing blocks. This makes it physically impossible for
-> the install to touch the wrong disk. Reconnect only in Phase 6. Confirm it's gone:
->
-> ```bash
-> talosctl -n $M get disks --insecure     # expect nvme0n1 (Apple SSD) + the USB stick only; no 1TB sda
-> ```
-
-Use a **temporary talconfig override** so all global patches (Cilium `cni: none`,
-network, sysctls, disks, longhorn label) are preserved:
+The node writes v1.13.5 (UKI, custom kernel) to `/dev/nvme0n1`, reboots, cold-boots
+cleanly, and rejoins as a worker (kubelet v1.35.6). Verify:
 
 ```bash
-cd kubernetes/bootstrap/talos
-cp talconfig.yaml /tmp/talconfig.step.yaml
-# In /tmp/talconfig.step.yaml set:
-#   talosVersion: v1.9.6
-#   kubernetesVersion: v1.32.x         # newest 1.32 patch Talos 1.9.6 supports
-# (leave the talmac-02 talosImageURL = the schematic; talhelper appends :v1.9.6)
-#
-# RECOMMENDED: pin the install disk by stable id instead of /dev/nvme0n1, so the
-# installer can only ever target the internal Apple SSD:
-#   nodes[talmac-02].installDiskSelector:
-#     model: "APPLE SSD AP0256M"        # or: serial: "<Apple SSD serial>"
-# With the enclosure unplugged this is redundant, but it protects against a stray
-# reconnect and against any node whose external disk enumerates as a real nvme.
-
-# Generate + apply via talhelper (mirrors `task talos:generate-config` + `apply-node`,
-# but against the temp config and in INSECURE maintenance mode):
-talhelper genconfig --config-file /tmp/talconfig.step.yaml \
-  --secret-file talsecret.sops.yaml --out-dir clusterconfig
-talhelper gencommand apply --node $M --config-file /tmp/talconfig.step.yaml \
-  --out-dir clusterconfig --extra-flags '--insecure' | bash
+talosctl -n $N version                                  # Talos v1.13.5
+talosctl -n $N get extensions | grep -E 'i915|thunderbolt|intel-ucode'   # present
+kubectl get node $H -o wide                              # Ready, v1.35.6
 ```
 
-The node installs v1.9.6 to the internal Apple SSD (`nvme0n1`) with **GRUB**, reboots
-onto the static `10.25.30.43`, and joins the cluster (kubelet 1.32). Verify:
+### 4. Prove it survives a cold boot
 
 ```bash
-talosctl -n $N version                              # Talos v1.9.6
-talosctl -n $N get securitystate | grep -i uki      # bootedWithUKI: FALSE  <-- GRUB
-talosctl -n $N get discoveredvolumes | grep -Ei 'BIOS|BOOT'   # BIOS + BOOT partitions present
-kubectl get node $H                                  # Ready, kubelet v1.32.x
+talosctl -n $N reboot        # comes back on its own = firmware boots the custom kernel
 ```
 
-> If `securitystate` still shows `bootedWithUKI: true`, STOP — the node booted the old
-> UKI install, not the USB. Re-check the wipe (Phase 2) and the boot source.
-
-### Phase 4 — Ladder up (GRUB preserved at every step)
-
-Repeat for **v1.10.9**, then **v1.11.6**, then **v1.12.9**:
+### 5. Restore workloads
 
 ```bash
-VER=v1.10.9          # then v1.11.6, then v1.12.9
-talosctl -n $N upgrade \
-  --image factory.talos.dev/installer/2385c7daef21b71bfd59f74b96cdccfebe5003bcef3cee5b56b1add17a8f4817:$VER \
-  --preserve
-# wait for reboot + rejoin
-talosctl -n $N version && kubectl get node $H
-talosctl -n $N get securitystate | grep -i uki       # MUST stay bootedWithUKI: false
-
-# bump kubelet to this release's max: edit kubernetesVersion in /tmp/talconfig.step.yaml
-# (keep talosVersion == the rung just installed), then:
-talhelper genconfig --config-file /tmp/talconfig.step.yaml \
-  --secret-file talsecret.sops.yaml --out-dir clusterconfig
-talosctl -n $N apply-config --file clusterconfig/kubernetes-talmac-02.yaml
-kubectl get node $H                                   # kubelet -> v1.33 / v1.34 / v1.35.6
-```
-
-kubelet targets per rung: v1.10.9→**v1.33.x**, v1.11.6→**v1.34.x**, v1.12.9→**v1.35.6**.
-
-### Phase 5 — Final rung: v1.13.5 (the one that used to hang)
-
-The node is now on v1.12.9, kubelet 1.35.6, still GRUB. Switch back to the **real,
-unmodified `talconfig.yaml`** (Talos v1.13.5 / k8s v1.35.6) — first remove talmac-02's
-version pin (Phase 7) so it tracks the global version — then:
-
-```bash
-cd kubernetes/bootstrap/talos
-task talos:generate-config                           # real talconfig -> v1.13.5 / v1.35.6
-talosctl -n $N apply-config --file clusterconfig/kubernetes-talmac-02.yaml
-talosctl -n $N upgrade \
-  --image factory.talos.dev/installer/2385c7daef21b71bfd59f74b96cdccfebe5003bcef3cee5b56b1add17a8f4817:v1.13.5 \
-  --preserve
-```
-
-Because the bootloader is still GRUB, the v1.13.5 kernel boots via the legacy x86 path
-and **does not hang**. Verify:
-
-```bash
-talosctl -n $N version                               # Talos v1.13.5
-talosctl -n $N get securitystate | grep -i uki       # bootedWithUKI: false (GRUB)
-kubectl get node $H                                   # Ready, v1.35.6
-```
-
-### Phase 6 — Reconnect + wipe the Longhorn disk, restore workloads
-
-The node is on v1.13.5. **Now reconnect the Longhorn USB enclosure.** It still holds the
-old, evacuated replica data + `longhorn-disk.cfg` — wipe it so Longhorn re-adds it as a
-clean disk with a fresh UUID (avoids re-adopting orphaned replica folders).
-
-```bash
-# 1. Confirm the enclosure is back and identify it (should be sda / usb transport)
-talosctl -n $N get disks | grep -i usb          # Intel/Sabrent 1TB on sda
-
-# 2. Wipe it (Talos >=1.10 has `wipe disk`; the node is on v1.13.5 here so this works).
-#    This clears the filesystem, longhorn-disk.cfg, and orphaned replica dirs.
-talosctl -n $N wipe disk sda --method=fast       # NEVER pass nvme0n1 (that's the OS disk)
-
-# 3. machine-disks.yaml re-partitions/mounts it at /var/mnt/longhorn-usb on next config
-#    reconcile (already in the applied config). Confirm the mount is present:
-talosctl -n $N get mounts | grep longhorn-usb
-```
-
-Clean up the stale Longhorn disk record and re-enable scheduling:
-
-```bash
-# The nodes.longhorn.io/talmac-02 CR still lists the OLD disk UUID(s) as failed. Let
-# Longhorn re-detect the fresh disk at /var/mnt/longhorn-usb, or remove the stale entry
-# via the Longhorn UI (Node > talmac-02 > Edit Disks) before re-enabling.
 kubectl uncordon $H
 kubectl -n longhorn-system patch nodes.longhorn.io $H --type=merge \
   -p '{"spec":{"allowScheduling":true,"evictionRequested":false}}'
-
-# Verify the disk is Schedulable and volumes settle
-kubectl -n longhorn-system get nodes.longhorn.io $H -o yaml | grep -A3 diskStatus | head
-kubectl -n longhorn-system get volumes.longhorn.io -o wide | grep -iv healthy   # expect empty
+kubectl -n longhorn-system get volumes.longhorn.io -o wide | grep -iv healthy   # -> empty
 ```
 
-### Phase 7 — Repo cleanup (talhelper)
+## Roll out to talmac-01 / talmac-03
 
-Once the node is confirmed healthy on v1.13.5:
+For each: drain + evacuate Longhorn (see below) → flash/boot the ISO OR
+`talosctl -n <ip> upgrade --image ghcr.io/mebezac/talos-mac/installer:v1.13.5 --preserve`
+(kexec upgrade is fine once already on the custom image; a first migration off stock
+UKI needs the ISO reinstall). Then in `talconfig.yaml`: set that node's `talosImageURL`
+to the custom installer and delete its `patches/talmac-0X/machine-install.yaml` pin.
+talmac-01 has a smarthome USB adapter — account for it.
 
-- Delete `patches/talmac-02/machine-install.yaml` and remove its
-  `- "@./patches/talmac-02/machine-install.yaml"` line from `talconfig.yaml`, so the node
-  tracks the global `talosVersion`. Keep `machine-disks.yaml`.
-- Update the `# Pinned to v1.12.4 …` comment on the talmac-02 node.
-- Leave talmac-01 and talmac-03 pinned until they are migrated the same way.
-- Commit normally. **ArgoCD does not manage the Talos layer** — this is
-  talhelper/bootstrap, applied manually.
+Evacuate before touching a node:
 
----
+```bash
+kubectl cordon $H
+kubectl -n longhorn-system patch nodes.longhorn.io $H --type=merge \
+  -p '{"spec":{"allowScheduling":false,"evictionRequested":true}}'
+# wait until 0 replicas remain on the node, all volumes still Healthy, then:
+kubectl drain $H --ignore-daemonsets --delete-emptydir-data --timeout=15m
+```
 
-## End-to-end verification
+## New Talos releases
 
-1. `talosctl -n 10.25.30.43 version` → **Talos v1.13.5**.
-2. `talosctl -n 10.25.30.43 get securitystate` → **`bootedWithUKI: false`** (GRUB — the
-   whole point; if this ever flipped to `true` mid-ladder, a step re-UKI'd the node).
-3. `talosctl -n 10.25.30.43 get discoveredvolumes` → BIOS + BOOT partitions present.
-4. `kubectl get node talmac-02` → `Ready`, kubelet **v1.35.6**.
-5. `talosctl -n 10.25.30.43 get extensions` → i915 / intel-ucode / iscsi-tools /
-   thunderbolt / util-linux-tools present (schematic preserved).
-6. `kubectl -n longhorn-system get volumes.longhorn.io` → all **Healthy**.
-7. Reboot test: `talosctl -n 10.25.30.43 reboot` → node returns cleanly (proves the
-   v1.13.5 kernel boots via GRUB on the Mac firmware without hanging).
+Tag `github.com/mebezac/talos-mac-installer` with the talos version (e.g. `v1.13.6`) to
+build a matching custom installer, bump `talosVersion` in `talconfig.yaml`, then
+`upgrade --image ghcr.io/mebezac/talos-mac/installer:v1.13.6 --preserve` per node. Never
+point a talmac at `factory.talos.dev` for v1.13+ — that's the hanging stock kernel.
 
-## Rollback / safety
+## Notes / gotchas
 
-- If an **upgrade** rung fails to return: it is a drained worker, so the cluster is
-  unaffected. Reboot to the previous GRUB A/B entry, or re-run the USB reinstall.
-- If the **v1.13.5** step hangs at the splash: the node was on UKI, not GRUB — restart
-  from Phase 2 (wipe → v1.9.6 USB).
-- Do **not** skip minors; sequential rungs keep config-schema migrations and the GRUB
-  bootloader intact.
-
-## Follow-up
-
-- Repeat for **talmac-01** (`10.25.30.42` — remove/account for its smarthome USB adapter
-  first) and **talmac-03** (`10.25.30.44`), one at a time.
-- Track siderolabs/talos#13579 — if Talos ships a non-LTO/fixed EFI-stub kernel, fresh
-  UKI installs may become viable and this GRUB dance can be retired.
+- Never wrap `talosctl reset`/`upgrade` in `timeout` — an interrupt leaves the node in a
+  half-reset LOCKED state. Background it instead.
+- Correct wipe flag is `--wipe-mode system-disk` (not `--system-disk-wipe-spec`).
+- factory DNS (node resolver 10.25.30.38) is flaky; a failed image pull is a safe no-op —
+  retry. (Less relevant now that installs pull from ghcr, not factory.)
+- The cluster k8s/API stays at v1.35; a talmac worker's kubelet may lag up to 3 minors,
+  so no cluster-wide downgrade is ever needed.

--- a/kubernetes/bootstrap/talos/docs/talmac-1.13-upgrade.md
+++ b/kubernetes/bootstrap/talos/docs/talmac-1.13-upgrade.md
@@ -147,27 +147,36 @@ Security Utility). Secure Boot stays off — the schematic is `secureboot: false
 
 ### Phase 2 — Wipe the UKI install & boot v1.9.6
 
-> **Unplug the Longhorn USB enclosure (`sda`) before this step.** Its replicas are
-> already evacuated (0 replicas after Phase 0), so its contents are disposable, and
-> unplugging it makes it *physically impossible* for the reset/installer to touch the
-> wrong disk. Reconnect it only in Phase 6. Belt-and-suspenders on top of the by-id pin.
+> **Leave the Longhorn USB enclosure (`sda`) PLUGGED IN for the reset.** ⚠️ Learned the
+> hard way: `machine.disks` references the enclosure, and Talos reset's volume-teardown
+> phase **blocks/locks** (`sequence not started: locked`) if that disk is absent — the
+> reset fails. Keep it plugged through the reset; you unplug it later, in maintenance mode
+> (Phase 3), before the install. The reset only wipes the **system disk**, so the plugged
+> enclosure is never at risk here.
 
 ```bash
-# Wipe ONLY the system disk so the Mac can't boot back into the old v1.12.4 UKI.
-# --system-disk-wipe-spec all wipes the internal Apple SSD; it does NOT touch user disks.
-# Do NOT pass --user-disks-to-wipe (that would wipe the Longhorn sda).
-talosctl -n $N reset --system-disk-wipe-spec all --reboot --graceful=false
+# Wipe ONLY the system disk (the internal Apple SSD) so the Mac can't boot back into the
+# old v1.12.4 UKI. --wipe-mode system-disk leaves ALL user disks (incl. the Longhorn sda)
+# untouched. Do NOT use --wipe-mode all or --user-disks-to-wipe.
+# ⚠️ Do NOT wrap this in `timeout` — the client abort signal interrupts the reset and
+#    leaves the node in a half-reset LOCKED state.
+talosctl -n $N reset --wipe-mode system-disk --reboot --graceful=false
 ```
 
-Boot the USB: power on holding **Option (⌥)** → pick **EFI Boot**. The node comes up in
-**maintenance mode** and DHCPs. Find its address (DHCP lease / console) and call it
-`$M`. Confirm only the internal disk is present (enclosure unplugged):
-
-```bash
-talosctl -n $M get disks --insecure     # expect nvme0n1 (Apple SSD) only; no sda
-```
+Boot the USB: power on holding **Option (⌥)** (keep holding until the boot picker appears)
+→ pick **EFI Boot** (the USB icon; if two appear, either works). The node comes up in
+**maintenance mode** and DHCPs (the static `10.25.30.43` was wiped). Find its address
+(DHCP lease / console) and call it `$M`.
 
 ### Phase 3 — Install v1.9.6 with kubelet 1.32 (via talhelper)
+
+> **Now unplug the Longhorn USB enclosure (`sda`)** — you're in maintenance mode, which
+> has no config referencing it, so nothing blocks. This makes it physically impossible for
+> the install to touch the wrong disk. Reconnect only in Phase 6. Confirm it's gone:
+>
+> ```bash
+> talosctl -n $M get disks --insecure     # expect nvme0n1 (Apple SSD) + the USB stick only; no 1TB sda
+> ```
 
 Use a **temporary talconfig override** so all global patches (Cilium `cni: none`,
 network, sysctls, disks, longhorn label) are preserved:

--- a/kubernetes/bootstrap/talos/docs/talmac-1.13-upgrade.md
+++ b/kubernetes/bootstrap/talos/docs/talmac-1.13-upgrade.md
@@ -7,20 +7,40 @@ Clang+LLD EFI stub that Apple's Intel firmware refuses to hand off to
 (siderolabs/talos#13579). An in-place `talosctl upgrade` *appears* to work because it
 kexecs the new kernel — but the box never survives a real power cycle.
 
-**The earlier GRUB-ladder idea in this doc's history was wrong** (Talos GRUB 2.14 also
-uses EFI hand-off, so it hangs too). The working fix is a **custom installer** built
-with the kernel linked by GNU ld instead of LLD:
+### Do NOT do the GRUB version ladder
+
+An earlier version of this doc proposed reinstalling from Talos **v1.9.6** (the last
+GRUB-defaulting release) and laddering the version up minor-by-minor, on the theory
+that GRUB's legacy boot path dodges the hang. **Do not do this — it does not work and
+it is pure downside:**
+
+1. **It doesn't actually fix the hang.** The hang is the *kernel's* Clang+LLD EFI stub
+   being rejected by Apple's firmware at hand-off. Talos's GRUB (2.14) hands off to that
+   *same* kernel/EFI stub, so a GRUB-booted v1.13 kernel hangs too. The bootloader was
+   never the problem — the kernel linkage is.
+2. **It can't survive a cold boot even if it seemed to.** An in-place `talosctl upgrade`
+   *looks* like it works because Talos **kexecs** the new kernel (bypassing firmware) —
+   but the box never survives a real power cycle. Any "it booted!" result mid-ladder is
+   a kexec false-positive, not proof the firmware can boot it.
+3. **It's slow, fragile, and destructive for nothing.** Five sequential reinstalls/
+   upgrades (v1.9.6 → 1.10 → 1.11 → 1.12 → 1.13), each a full node wipe + Longhorn
+   replica rebuild + config-schema migration, versus a single `talosctl upgrade` onto
+   the custom image. More reboots, more evacuations, more chances to brick a node — to
+   arrive at a kernel that still hangs on cold boot.
+
+The **only** thing that fixes it is a kernel linked by **GNU ld instead of LLD**, which
+Apple's firmware accepts. So we use a **custom installer** built with exactly that:
 
 - Repo: `github.com/mebezac/talos-mac-installer` (builds via GitHub Actions on tag push)
 - Installer image: `ghcr.io/mebezac/talos-mac/installer:<talos-version>`
 - USB ISO: attached to the matching GitHub Release (`metal-amd64.iso`)
 
 A GCC-linked kernel cold-boots fine under UKI/systemd-boot, so **no GRUB, no version
-ladder** — the Mac upgrades like any other node once it's on the custom image.
+ladder, no downgrade** — the Mac upgrades like any other node once it's on the custom
+image.
 
-`talconfig.yaml` already points **talmac-02** at `ghcr.io/mebezac/talos-mac/installer`
-(talhelper appends `:${talosVersion}`). talmac-01/03 remain on their v1.12.4 pins until
-migrated the same way.
+All three talmacs (talmac-01/02/03) now point at `ghcr.io/mebezac/talos-mac/installer`
+in `talconfig.yaml` (talhelper appends `:${talosVersion}`) with no version pins.
 
 ## Recover talmac-02 (10.25.30.43) — currently down on a non-booting stock v1.13.5
 

--- a/kubernetes/bootstrap/talos/docs/talmac-1.13-upgrade.md
+++ b/kubernetes/bootstrap/talos/docs/talmac-1.13-upgrade.md
@@ -1,0 +1,246 @@
+# Runbook: Migrating an Intel Mac mini node onto Talos v1.13.x
+
+Getting a `talmac-*` node (Intel `Macmini8,1`, 2018 T2) from its pinned **Talos
+v1.12.4** up to **v1.13.x** without hitting the Intel-Mac boot hang.
+
+Worked example targets **talmac-02** (`10.25.30.43`); the procedure is parameterized
+(`$N` / `$H`) so it also applies to talmac-01 (`10.25.30.42`) and talmac-03
+(`10.25.30.44`). Do one node at a time.
+
+---
+
+## Why this is not a normal upgrade
+
+Talos **v1.13.x hangs at the TALOS splash on Intel Macs**. Root cause: the v1.13
+kernel's Clang+LLD/ThinLTO EFI stub, which Apple's Intel EFI firmware cannot hand off
+to during a cold UEFI boot (siderolabs/talos#13579 — affects Ubuntu/Debian too, not
+Talos-specific).
+
+The UKI/systemd-boot default landed in **Talos 1.10**. The talmacs were installed fresh
+at v1.12.4, so they boot via **UKI/sd-boot** (`bootedWithUKI: true`; partition layout
+`EFI/META/STATE/EPHEMERAL`, no BIOS/BOOT). **Talos upgrades preserve the existing
+bootloader**, so a UKI node upgraded in place to v1.13.x stays on UKI and hangs.
+
+The fix: reinstall from **v1.9.6** — the last GRUB-defaulting release — then ladder the
+Talos version up one minor at a time. GRUB uses the legacy x86 boot protocol that boots
+fine on Mac firmware, and it is preserved across every upgrade, so it rides all the way
+to v1.13.x and dodges the hang.
+
+### Kubernetes version — no cluster downgrade
+
+The cluster's k8s version is the **control-plane/API-server** version (1.35) and does
+not change. A worker only runs a **kubelet**, and the k8s skew policy (≥1.28) allows a
+kubelet up to **3 minors older** than the API server — so kubelet 1.32 (Talos 1.9.6's
+max) is fully supported against a 1.35 API server. Kubelet walks up with Talos, reaching
+1.35.6 at the end. Only this one worker runs an older kubelet, transiently.
+
+---
+
+## Node facts (talmac-02, verified live)
+
+- IP `10.25.30.43`, hostname `talmac-02`, install disk `/dev/nvme0n1` (Apple SSD).
+- Also has a USB Longhorn disk mounted at `/var/mnt/longhorn-usb`.
+- Factory schematic `2385c7daef21b71bfd59f74b96cdccfebe5003bcef3cee5b56b1add17a8f4817`
+  = extensions `i915, intel-ucode, iscsi-tools, thunderbolt, util-linux-tools`
+  + kernel args `intel_iommu=on iommu=pt pcie_ports=compat`.
+  `pcie_ports=compat` is what makes the Apple NVMe usable — it must be present at every
+  step. Using the same schematic for every install/upgrade image keeps it consistent.
+
+## Version ladder (sequential — do not skip minors)
+
+| Step | Talos | kubelet (worker) | Bootloader |
+|-|-|-|-|
+| Fresh install | v1.9.6 | v1.32.x | **GRUB** (last GRUB-default release) |
+| Upgrade 1 | v1.10.9 | v1.33.x | GRUB (preserved) |
+| Upgrade 2 | v1.11.6 | v1.34.x | GRUB (preserved) |
+| Upgrade 3 | v1.12.9 | v1.35.6 | GRUB (preserved) |
+| Upgrade 4 | v1.13.5 | v1.35.6 | GRUB (preserved) — **no hang** |
+
+Rule per rung: **upgrade Talos first, then bump kubelet** to that release's max
+(kubelet ≤ Talos-supported k8s max, and ≤ API server 1.35). Pick the newest patch of
+each k8s minor; check the target Talos release notes' supported-k8s range.
+
+All installer/upgrade images use the same schematic:
+`factory.talos.dev/installer/2385c7daef21b71bfd59f74b96cdccfebe5003bcef3cee5b56b1add17a8f4817:<version>`
+
+---
+
+## Procedure
+
+### Phase 0 — Pre-flight & evacuate (graceful)
+
+```bash
+N=10.25.30.43 ; H=talmac-02
+talosctl -n $N version                            # expect Talos v1.12.4
+talosctl -n $N get securitystate | grep -i uki    # bootedWithUKI: true (why we reinstall)
+kubectl get node $H -o wide                        # note current kubelet
+
+# Cordon + stop Longhorn scheduling and request replica eviction off this node
+kubectl cordon $H
+kubectl -n longhorn-system patch nodes.longhorn.io $H --type=merge \
+  -p '{"spec":{"allowScheduling":false,"evictionRequested":true}}'
+
+# Wait until NO replicas remain on the node (rebuilt elsewhere), all volumes still Healthy
+watch "kubectl -n longhorn-system get replicas.longhorn.io -o wide | grep -c $H"   # -> 0
+
+# Drain workloads
+kubectl drain $H --ignore-daemonsets --delete-emptydir-data --timeout=15m
+```
+
+Step 2 covers replicas on both the internal NVMe and the USB Longhorn disk.
+
+### Phase 1 — Build the v1.9.6 GRUB USB
+
+```bash
+curl -LO "https://factory.talos.dev/image/2385c7daef21b71bfd59f74b96cdccfebe5003bcef3cee5b56b1add17a8f4817/v1.9.6/metal-amd64.iso"
+
+# Write to USB (macOS): identify, unmount, dd to the RAW device
+diskutil list
+diskutil unmountDisk /dev/diskN
+sudo dd if=metal-amd64.iso of=/dev/rdiskN bs=4m status=progress
+sync ; diskutil eject /dev/diskN
+```
+
+T2 Startup Security (should already be set from the original install; verify if boot
+fails): **Reduced Security + Allow booting from external media** (recoveryOS → Startup
+Security Utility). Secure Boot stays off — the schematic is `secureboot: false`.
+
+### Phase 2 — Wipe the UKI install & boot v1.9.6
+
+```bash
+# Wipe the existing v1.12.4 UKI system so the Mac can't boot back into it
+talosctl -n $N reset --system-labels-to-wipe STATE,EPHEMERAL --reboot --graceful=false
+# (or full wipe: --system-disk-wipe-spec all)
+```
+
+Boot the USB: power on holding **Option (⌥)** → pick **EFI Boot**. The node comes up in
+**maintenance mode** and DHCPs. Find its address (DHCP lease / console) and call it
+`$M`.
+
+### Phase 3 — Install v1.9.6 with kubelet 1.32 (via talhelper)
+
+Use a **temporary talconfig override** so all global patches (Cilium `cni: none`,
+network, sysctls, disks, longhorn label) are preserved:
+
+```bash
+cd kubernetes/bootstrap/talos
+cp talconfig.yaml /tmp/talconfig.step.yaml
+# In /tmp/talconfig.step.yaml set:
+#   talosVersion: v1.9.6
+#   kubernetesVersion: v1.32.x         # newest 1.32 patch Talos 1.9.6 supports
+# (leave the talmac-02 talosImageURL = the schematic; talhelper appends :v1.9.6)
+
+talhelper genconfig -c /tmp/talconfig.step.yaml   # -> clusterconfig/kubernetes-talmac-02.yaml
+talosctl apply-config --insecure -n $M --file clusterconfig/kubernetes-talmac-02.yaml
+```
+
+The node installs v1.9.6 to `/dev/nvme0n1` with **GRUB**, reboots onto the static
+`10.25.30.43`, and joins the cluster (kubelet 1.32). Verify:
+
+```bash
+talosctl -n $N version                              # Talos v1.9.6
+talosctl -n $N get securitystate | grep -i uki      # bootedWithUKI: FALSE  <-- GRUB
+talosctl -n $N get discoveredvolumes | grep -Ei 'BIOS|BOOT'   # BIOS + BOOT partitions present
+kubectl get node $H                                  # Ready, kubelet v1.32.x
+```
+
+> If `securitystate` still shows `bootedWithUKI: true`, STOP — the node booted the old
+> UKI install, not the USB. Re-check the wipe (Phase 2) and the boot source.
+
+### Phase 4 — Ladder up (GRUB preserved at every step)
+
+Repeat for **v1.10.9**, then **v1.11.6**, then **v1.12.9**:
+
+```bash
+VER=v1.10.9          # then v1.11.6, then v1.12.9
+talosctl -n $N upgrade \
+  --image factory.talos.dev/installer/2385c7daef21b71bfd59f74b96cdccfebe5003bcef3cee5b56b1add17a8f4817:$VER \
+  --preserve
+# wait for reboot + rejoin
+talosctl -n $N version && kubectl get node $H
+talosctl -n $N get securitystate | grep -i uki       # MUST stay bootedWithUKI: false
+
+# bump kubelet to this release's max: edit kubernetesVersion in /tmp/talconfig.step.yaml
+# (keep talosVersion == the rung just installed), then:
+talhelper genconfig -c /tmp/talconfig.step.yaml
+talosctl -n $N apply-config --file clusterconfig/kubernetes-talmac-02.yaml
+kubectl get node $H                                   # kubelet -> v1.33 / v1.34 / v1.35.6
+```
+
+kubelet targets per rung: v1.10.9→**v1.33.x**, v1.11.6→**v1.34.x**, v1.12.9→**v1.35.6**.
+
+### Phase 5 — Final rung: v1.13.5 (the one that used to hang)
+
+The node is now on v1.12.9, kubelet 1.35.6, still GRUB. Switch back to the **real,
+unmodified `talconfig.yaml`** (Talos v1.13.5 / k8s v1.35.6) — first remove talmac-02's
+version pin (Phase 7) so it tracks the global version — then:
+
+```bash
+cd kubernetes/bootstrap/talos
+talhelper genconfig                                  # real talconfig -> v1.13.5 / v1.35.6
+talosctl -n $N apply-config --file clusterconfig/kubernetes-talmac-02.yaml
+talosctl -n $N upgrade \
+  --image factory.talos.dev/installer/2385c7daef21b71bfd59f74b96cdccfebe5003bcef3cee5b56b1add17a8f4817:v1.13.5 \
+  --preserve
+```
+
+Because the bootloader is still GRUB, the v1.13.5 kernel boots via the legacy x86 path
+and **does not hang**. Verify:
+
+```bash
+talosctl -n $N version                               # Talos v1.13.5
+talosctl -n $N get securitystate | grep -i uki       # bootedWithUKI: false (GRUB)
+kubectl get node $H                                   # Ready, v1.35.6
+```
+
+### Phase 6 — Restore workloads & Longhorn
+
+```bash
+kubectl uncordon $H
+kubectl -n longhorn-system patch nodes.longhorn.io $H --type=merge \
+  -p '{"spec":{"allowScheduling":true,"evictionRequested":false}}'
+kubectl -n longhorn-system get volumes.longhorn.io -o wide | grep -iv healthy   # expect empty
+```
+
+### Phase 7 — Repo cleanup (talhelper)
+
+Once the node is confirmed healthy on v1.13.5:
+
+- Delete `patches/talmac-02/machine-install.yaml` and remove its
+  `- "@./patches/talmac-02/machine-install.yaml"` line from `talconfig.yaml`, so the node
+  tracks the global `talosVersion`. Keep `machine-disks.yaml`.
+- Update the `# Pinned to v1.12.4 …` comment on the talmac-02 node.
+- Leave talmac-01 and talmac-03 pinned until they are migrated the same way.
+- Commit normally. **ArgoCD does not manage the Talos layer** — this is
+  talhelper/bootstrap, applied manually.
+
+---
+
+## End-to-end verification
+
+1. `talosctl -n 10.25.30.43 version` → **Talos v1.13.5**.
+2. `talosctl -n 10.25.30.43 get securitystate` → **`bootedWithUKI: false`** (GRUB — the
+   whole point; if this ever flipped to `true` mid-ladder, a step re-UKI'd the node).
+3. `talosctl -n 10.25.30.43 get discoveredvolumes` → BIOS + BOOT partitions present.
+4. `kubectl get node talmac-02` → `Ready`, kubelet **v1.35.6**.
+5. `talosctl -n 10.25.30.43 get extensions` → i915 / intel-ucode / iscsi-tools /
+   thunderbolt / util-linux-tools present (schematic preserved).
+6. `kubectl -n longhorn-system get volumes.longhorn.io` → all **Healthy**.
+7. Reboot test: `talosctl -n 10.25.30.43 reboot` → node returns cleanly (proves the
+   v1.13.5 kernel boots via GRUB on the Mac firmware without hanging).
+
+## Rollback / safety
+
+- If an **upgrade** rung fails to return: it is a drained worker, so the cluster is
+  unaffected. Reboot to the previous GRUB A/B entry, or re-run the USB reinstall.
+- If the **v1.13.5** step hangs at the splash: the node was on UKI, not GRUB — restart
+  from Phase 2 (wipe → v1.9.6 USB).
+- Do **not** skip minors; sequential rungs keep config-schema migrations and the GRUB
+  bootloader intact.
+
+## Follow-up
+
+- Repeat for **talmac-01** (`10.25.30.42` — remove/account for its smarthome USB adapter
+  first) and **talmac-03** (`10.25.30.44`), one at a time.
+- Track siderolabs/talos#13579 — if Talos ships a non-LTO/fixed EFI-stub kernel, fresh
+  UKI installs may become viable and this GRUB dance can be retired.

--- a/kubernetes/bootstrap/talos/docs/talmac-1.13-upgrade.md
+++ b/kubernetes/bootstrap/talos/docs/talmac-1.13-upgrade.md
@@ -92,14 +92,39 @@ kubectl -n longhorn-system patch nodes.longhorn.io $H --type=merge \
 kubectl -n longhorn-system get volumes.longhorn.io -o wide | grep -iv healthy   # -> empty
 ```
 
-## Roll out to talmac-01 / talmac-03
+## Roll out to talmac-01 / talmac-03 (in-place upgrade — no USB needed)
 
-For each: drain + evacuate Longhorn (see below) → flash/boot the ISO OR
-`talosctl -n <ip> upgrade --image ghcr.io/mebezac/talos-mac/installer:v1.13.5 --preserve`
-(kexec upgrade is fine once already on the custom image; a first migration off stock
-UKI needs the ISO reinstall). Then in `talconfig.yaml`: set that node's `talosImageURL`
-to the custom installer and delete its `patches/talmac-0X/machine-install.yaml` pin.
-talmac-01 has a smarthome USB adapter — account for it.
+A working node (e.g. on v1.12.4) can be upgraded **in place** — no USB, no wipe, no
+Longhorn disk re-adoption (`--preserve` keeps the disks, so replicas survive the
+reboot):
+
+```bash
+N=<ip> ; H=talmac-0X
+kubectl cordon $H
+kubectl -n longhorn-system patch nodes.longhorn.io $H --type=merge \
+  -p '{"spec":{"allowScheduling":false,"evictionRequested":false}}'   # NO eviction — preserve keeps replicas
+kubectl drain $H --ignore-daemonsets --delete-emptydir-data --timeout=15m
+talosctl -n $N upgrade --image ghcr.io/mebezac/talos-mac/installer:v1.13.5 --preserve
+```
+
+**Expect a non-fatal error.** The upgrade reports:
+`failed to install bootloader: failed to create boot entry: ... BootFFFF: declared
+length of FilePath (166) overruns available data (165)` and exits 1 — Apple's EFI NVRAM
+has a malformed `BootFFFF` variable that Talos's boot-entry enumeration can't parse.
+This is **cosmetic**: the new v1.13.5 UKI is written to the ESP and systemd-boot (already
+the installed boot manager) boots it. Verify the node actually came up on v1.13.5
+(`talosctl -n $N version` → v1.13.5, kernel `6.18.36-talos`) — it will have, despite the
+error — then `kubectl uncordon $H` + restore Longhorn scheduling.
+
+Then in `talconfig.yaml`: set that node's `talosImageURL` to the custom installer and
+delete its `patches/talmac-0X/machine-install.yaml` pin.
+
+- **talmac-01** — migrated 2026-07-04 via this in-place path (Ready on v1.13.5).
+- **talmac-03** — its USB Longhorn enclosure was physically unplugged for a while; plug
+  it back before upgrading so the `machine-disks.yaml` mount resolves.
+- A full **USB ISO reinstall** (Phase 1-3 above) is only needed to recover a node that's
+  already bricked on a non-booting stock v1.13.x (as talmac-02 was) — not for a normal
+  migration off a working v1.12.x.
 
 Evacuate before touching a node:
 

--- a/kubernetes/bootstrap/talos/docs/talmac-1.13-upgrade.md
+++ b/kubernetes/bootstrap/talos/docs/talmac-1.13-upgrade.md
@@ -38,13 +38,53 @@ max) is fully supported against a 1.35 API server. Kubelet walks up with Talos, 
 
 ## Node facts (talmac-02, verified live)
 
-- IP `10.25.30.43`, hostname `talmac-02`, install disk `/dev/nvme0n1` (Apple SSD).
-- Also has a USB Longhorn disk mounted at `/var/mnt/longhorn-usb`.
+- IP `10.25.30.43`, hostname `talmac-02`.
+- **Two disks — know which is which before wiping anything:**
+
+  | Role | Device | Transport | Identity | Stable by-id |
+  |-|-|-|-|-|
+  | **OS / install** | `nvme0n1` | nvme | Apple SSD AP0256M, 251 GB | `nvme-APPLE_SSD_AP0256M_<serial>` |
+  | **Longhorn** | `sda` | **usb** | Intel 670p 1 TB in Sabrent enclosure | `usb-Sabrent_SSD_<serial>-0:0`, mounted `/var/mnt/longhorn-usb` |
+
+  The Longhorn NVMe bridges over **USB** (`sda`), not as a native NVMe — so the internal
+  Apple SSD is the **only** `nvme` device and `/dev/nvme0n1` is unambiguous. (If a talmac
+  ever shows the external disk as a real `nvme1n1`, the disk-by-id pin below becomes
+  mandatory, not just insurance.) Verify per node with `talosctl -n <ip> get disks` and
+  `talosctl -n <ip> get systemdisk` before touching disks.
 - Factory schematic `2385c7daef21b71bfd59f74b96cdccfebe5003bcef3cee5b56b1add17a8f4817`
   = extensions `i915, intel-ucode, iscsi-tools, thunderbolt, util-linux-tools`
   + kernel args `intel_iommu=on iommu=pt pcie_ports=compat`.
   `pcie_ports=compat` is what makes the Apple NVMe usable — it must be present at every
   step. Using the same schematic for every install/upgrade image keeps it consistent.
+
+## Tooling: talhelper + Taskfile (read before running commands)
+
+This repo drives Talos through **talhelper** wrapped in `.taskfiles/talos`. Normal ops:
+
+| Task | What it runs |
+|-|-|
+| `task talos:generate-config` | `talhelper genconfig` → `clusterconfig/` |
+| `task talos:apply-node IP=<ip>` | `talhelper gencommand apply --node <ip> --extra-flags '--mode=auto' \| bash` |
+| `task talos:upgrade-node IP=<ip>` | `talhelper gencommand upgrade` with `--image=factory.../<schematic>:<ver> --preserve` |
+| `task talos:upgrade-k8s` | `talhelper gencommand upgrade-k8s --to <ver>` |
+| `task talos:reset` | `talhelper gencommand reset --system-labels-to-wipe STATE,EPHEMERAL` |
+
+`TALOSCONFIG` = `clusterconfig/talosconfig`, secret file = `talsecret.sops.yaml`, config =
+`talconfig.yaml` — all exported by the root `Taskfile.yaml`. Run tasks from repo root; if
+you invoke `talosctl`/`talhelper` directly, `export TALOSCONFIG=$(pwd)/kubernetes/bootstrap/talos/clusterconfig/talosconfig` first.
+
+**This runbook deliberately deviates from those tasks in three spots — do not "simplify"
+them back to the tasks:**
+
+1. **`upgrade-node` / `upgrade-k8s` read the *global* `.talosVersion` / `.kubernetesVersion`**
+   (v1.13.5 / v1.35.6). Running them would jump straight to v1.13.5 and defeat the ladder.
+   The intermediate rungs therefore drive `talhelper gencommand ... --config-file /tmp/talconfig.step.yaml`
+   (a temp copy pinned to each rung) or raw `talosctl upgrade --image ...:<rung>`.
+2. **The repo's `reset` only wipes STATE+EPHEMERAL**, leaving the EFI/UKI partition — a Mac
+   could then re-boot the old install instead of the USB. Phase 2 uses full
+   `--system-disk-wipe-spec all` on purpose.
+3. **Maintenance-mode apply needs `--insecure`** (the `apply-node` task's preconditions
+   assume a live node with an issued cert). Phase 3 calls it explicitly.
 
 ## Version ladder (sequential — do not skip minors)
 
@@ -107,15 +147,25 @@ Security Utility). Secure Boot stays off — the schematic is `secureboot: false
 
 ### Phase 2 — Wipe the UKI install & boot v1.9.6
 
+> **Unplug the Longhorn USB enclosure (`sda`) before this step.** Its replicas are
+> already evacuated (0 replicas after Phase 0), so its contents are disposable, and
+> unplugging it makes it *physically impossible* for the reset/installer to touch the
+> wrong disk. Reconnect it only in Phase 6. Belt-and-suspenders on top of the by-id pin.
+
 ```bash
-# Wipe the existing v1.12.4 UKI system so the Mac can't boot back into it
-talosctl -n $N reset --system-labels-to-wipe STATE,EPHEMERAL --reboot --graceful=false
-# (or full wipe: --system-disk-wipe-spec all)
+# Wipe ONLY the system disk so the Mac can't boot back into the old v1.12.4 UKI.
+# --system-disk-wipe-spec all wipes the internal Apple SSD; it does NOT touch user disks.
+# Do NOT pass --user-disks-to-wipe (that would wipe the Longhorn sda).
+talosctl -n $N reset --system-disk-wipe-spec all --reboot --graceful=false
 ```
 
 Boot the USB: power on holding **Option (⌥)** → pick **EFI Boot**. The node comes up in
 **maintenance mode** and DHCPs. Find its address (DHCP lease / console) and call it
-`$M`.
+`$M`. Confirm only the internal disk is present (enclosure unplugged):
+
+```bash
+talosctl -n $M get disks --insecure     # expect nvme0n1 (Apple SSD) only; no sda
+```
 
 ### Phase 3 — Install v1.9.6 with kubelet 1.32 (via talhelper)
 
@@ -129,13 +179,24 @@ cp talconfig.yaml /tmp/talconfig.step.yaml
 #   talosVersion: v1.9.6
 #   kubernetesVersion: v1.32.x         # newest 1.32 patch Talos 1.9.6 supports
 # (leave the talmac-02 talosImageURL = the schematic; talhelper appends :v1.9.6)
+#
+# RECOMMENDED: pin the install disk by stable id instead of /dev/nvme0n1, so the
+# installer can only ever target the internal Apple SSD:
+#   nodes[talmac-02].installDiskSelector:
+#     model: "APPLE SSD AP0256M"        # or: serial: "<Apple SSD serial>"
+# With the enclosure unplugged this is redundant, but it protects against a stray
+# reconnect and against any node whose external disk enumerates as a real nvme.
 
-talhelper genconfig -c /tmp/talconfig.step.yaml   # -> clusterconfig/kubernetes-talmac-02.yaml
-talosctl apply-config --insecure -n $M --file clusterconfig/kubernetes-talmac-02.yaml
+# Generate + apply via talhelper (mirrors `task talos:generate-config` + `apply-node`,
+# but against the temp config and in INSECURE maintenance mode):
+talhelper genconfig --config-file /tmp/talconfig.step.yaml \
+  --secret-file talsecret.sops.yaml --out-dir clusterconfig
+talhelper gencommand apply --node $M --config-file /tmp/talconfig.step.yaml \
+  --out-dir clusterconfig --extra-flags '--insecure' | bash
 ```
 
-The node installs v1.9.6 to `/dev/nvme0n1` with **GRUB**, reboots onto the static
-`10.25.30.43`, and joins the cluster (kubelet 1.32). Verify:
+The node installs v1.9.6 to the internal Apple SSD (`nvme0n1`) with **GRUB**, reboots
+onto the static `10.25.30.43`, and joins the cluster (kubelet 1.32). Verify:
 
 ```bash
 talosctl -n $N version                              # Talos v1.9.6
@@ -162,7 +223,8 @@ talosctl -n $N get securitystate | grep -i uki       # MUST stay bootedWithUKI: 
 
 # bump kubelet to this release's max: edit kubernetesVersion in /tmp/talconfig.step.yaml
 # (keep talosVersion == the rung just installed), then:
-talhelper genconfig -c /tmp/talconfig.step.yaml
+talhelper genconfig --config-file /tmp/talconfig.step.yaml \
+  --secret-file talsecret.sops.yaml --out-dir clusterconfig
 talosctl -n $N apply-config --file clusterconfig/kubernetes-talmac-02.yaml
 kubectl get node $H                                   # kubelet -> v1.33 / v1.34 / v1.35.6
 ```
@@ -177,7 +239,7 @@ version pin (Phase 7) so it tracks the global version — then:
 
 ```bash
 cd kubernetes/bootstrap/talos
-talhelper genconfig                                  # real talconfig -> v1.13.5 / v1.35.6
+task talos:generate-config                           # real talconfig -> v1.13.5 / v1.35.6
 talosctl -n $N apply-config --file clusterconfig/kubernetes-talmac-02.yaml
 talosctl -n $N upgrade \
   --image factory.talos.dev/installer/2385c7daef21b71bfd59f74b96cdccfebe5003bcef3cee5b56b1add17a8f4817:v1.13.5 \
@@ -193,12 +255,37 @@ talosctl -n $N get securitystate | grep -i uki       # bootedWithUKI: false (GRU
 kubectl get node $H                                   # Ready, v1.35.6
 ```
 
-### Phase 6 — Restore workloads & Longhorn
+### Phase 6 — Reconnect + wipe the Longhorn disk, restore workloads
+
+The node is on v1.13.5. **Now reconnect the Longhorn USB enclosure.** It still holds the
+old, evacuated replica data + `longhorn-disk.cfg` — wipe it so Longhorn re-adds it as a
+clean disk with a fresh UUID (avoids re-adopting orphaned replica folders).
 
 ```bash
+# 1. Confirm the enclosure is back and identify it (should be sda / usb transport)
+talosctl -n $N get disks | grep -i usb          # Intel/Sabrent 1TB on sda
+
+# 2. Wipe it (Talos >=1.10 has `wipe disk`; the node is on v1.13.5 here so this works).
+#    This clears the filesystem, longhorn-disk.cfg, and orphaned replica dirs.
+talosctl -n $N wipe disk sda --method=fast       # NEVER pass nvme0n1 (that's the OS disk)
+
+# 3. machine-disks.yaml re-partitions/mounts it at /var/mnt/longhorn-usb on next config
+#    reconcile (already in the applied config). Confirm the mount is present:
+talosctl -n $N get mounts | grep longhorn-usb
+```
+
+Clean up the stale Longhorn disk record and re-enable scheduling:
+
+```bash
+# The nodes.longhorn.io/talmac-02 CR still lists the OLD disk UUID(s) as failed. Let
+# Longhorn re-detect the fresh disk at /var/mnt/longhorn-usb, or remove the stale entry
+# via the Longhorn UI (Node > talmac-02 > Edit Disks) before re-enabling.
 kubectl uncordon $H
 kubectl -n longhorn-system patch nodes.longhorn.io $H --type=merge \
   -p '{"spec":{"allowScheduling":true,"evictionRequested":false}}'
+
+# Verify the disk is Schedulable and volumes settle
+kubectl -n longhorn-system get nodes.longhorn.io $H -o yaml | grep -A3 diskStatus | head
 kubectl -n longhorn-system get volumes.longhorn.io -o wide | grep -iv healthy   # expect empty
 ```
 

--- a/kubernetes/bootstrap/talos/docs/talmac-1.13-upgrade.md
+++ b/kubernetes/bootstrap/talos/docs/talmac-1.13-upgrade.md
@@ -120,8 +120,14 @@ Then in `talconfig.yaml`: set that node's `talosImageURL` to the custom installe
 delete its `patches/talmac-0X/machine-install.yaml` pin.
 
 - **talmac-01** — migrated 2026-07-04 via this in-place path (Ready on v1.13.5).
-- **talmac-03** — its USB Longhorn enclosure was physically unplugged for a while; plug
-  it back before upgrading so the `machine-disks.yaml` mount resolves.
+- **talmac-03** — migrated 2026-07-04 via this in-place path (Ready on v1.13.5). Its USB
+  Longhorn enclosure had been unplugged for a while and, once replugged, the old mount
+  was stale (`/var/mnt/longhorn-usb` bound to a dead `/dev/sda1`, `input/output error`
+  reading `longhorn-disk.cfg`, Longhorn disk `Ready: False`). **The upgrade's reboot
+  fixed it** — Talos re-resolved the `by-id` mount to the re-enumerated device and
+  Longhorn re-adopted both disks automatically (on-disk `diskUUID` still matched the node
+  CR, so no disable/remove/re-add dance was needed). All three talmacs are now on the
+  custom installer with no version pins.
 - A full **USB ISO reinstall** (Phase 1-3 above) is only needed to recover a node that's
   already bricked on a non-booting stock v1.13.x (as talmac-02 was) — not for a normal
   migration off a working v1.12.x.

--- a/kubernetes/bootstrap/talos/patches/talmac-01/machine-install.yaml
+++ b/kubernetes/bootstrap/talos/patches/talmac-01/machine-install.yaml
@@ -1,3 +1,0 @@
-machine:
-  install:
-    image: factory.talos.dev/installer/2385c7daef21b71bfd59f74b96cdccfebe5003bcef3cee5b56b1add17a8f4817:v1.12.4

--- a/kubernetes/bootstrap/talos/patches/talmac-02/machine-install.yaml
+++ b/kubernetes/bootstrap/talos/patches/talmac-02/machine-install.yaml
@@ -1,3 +1,0 @@
-machine:
-  install:
-    image: factory.talos.dev/installer/2385c7daef21b71bfd59f74b96cdccfebe5003bcef3cee5b56b1add17a8f4817:v1.12.4

--- a/kubernetes/bootstrap/talos/patches/talmac-03/machine-install.yaml
+++ b/kubernetes/bootstrap/talos/patches/talmac-03/machine-install.yaml
@@ -1,3 +1,0 @@
-machine:
-  install:
-    image: factory.talos.dev/installer/2385c7daef21b71bfd59f74b96cdccfebe5003bcef3cee5b56b1add17a8f4817:v1.12.4

--- a/kubernetes/bootstrap/talos/talconfig.yaml
+++ b/kubernetes/bootstrap/talos/talconfig.yaml
@@ -171,12 +171,16 @@ nodes:
     installDisk: "/dev/nvme0n1"
     machineSpec:
       secureboot: false
-    talosImageURL: factory.talos.dev/installer/2385c7daef21b71bfd59f74b96cdccfebe5003bcef3cee5b56b1add17a8f4817
+    # Custom GCC-linked installer (github.com/mebezac/talos-mac-installer) — stock Talos
+    # 1.13 hangs at cold boot on the T2 Mac (LLD EFI stub, siderolabs/talos#13579).
+    # In-place `talosctl upgrade` to this image works but reports a non-fatal error
+    # ("failed to create boot entry: BootFFFF ... overruns available data") — Apple's
+    # EFI NVRAM is malformed; systemd-boot still boots the new UKI. talhelper appends
+    # :${talosVersion} (v1.13.5). Migrated in place 2026-07-04.
+    talosImageURL: ghcr.io/mebezac/talos-mac/installer
     controlPlane: false
     patches:
       - "@./patches/talmac-03/machine-disks.yaml"
-      # Pinned to v1.12.4 — v1.13.0 boot-loops on the 2018 Mac mini (T2)
-      - "@./patches/talmac-03/machine-install.yaml"
     networkInterfaces:
       - deviceSelector:
           hardwareAddr: "3c:cd:36:69:f8:de"

--- a/kubernetes/bootstrap/talos/talconfig.yaml
+++ b/kubernetes/bootstrap/talos/talconfig.yaml
@@ -123,12 +123,16 @@ nodes:
     installDisk: "/dev/nvme0n1"
     machineSpec:
       secureboot: false
-    talosImageURL: factory.talos.dev/installer/2385c7daef21b71bfd59f74b96cdccfebe5003bcef3cee5b56b1add17a8f4817
+    # Custom GCC-linked installer (github.com/mebezac/talos-mac-installer) — stock Talos
+    # 1.13 hangs at cold boot on the T2 Mac (LLD EFI stub, siderolabs/talos#13579).
+    # In-place `talosctl upgrade` to this image works but reports a non-fatal error
+    # ("failed to create boot entry: BootFFFF ... overruns available data") — Apple's
+    # EFI NVRAM is malformed; systemd-boot still boots the new UKI. talhelper appends
+    # :${talosVersion} (v1.13.5).
+    talosImageURL: ghcr.io/mebezac/talos-mac/installer
     controlPlane: false
     patches:
       - "@./patches/talmac-01/machine-disks.yaml"
-      # Pinned to v1.12.4 — v1.13.0 boot-loops on the 2018 Mac mini (T2)
-      - "@./patches/talmac-01/machine-install.yaml"
     networkInterfaces:
       - deviceSelector:
           hardwareAddr: "3c:cd:36:69:f7:f8"

--- a/kubernetes/bootstrap/talos/talconfig.yaml
+++ b/kubernetes/bootstrap/talos/talconfig.yaml
@@ -144,12 +144,14 @@ nodes:
     installDisk: "/dev/nvme0n1"
     machineSpec:
       secureboot: false
-    talosImageURL: factory.talos.dev/installer/2385c7daef21b71bfd59f74b96cdccfebe5003bcef3cee5b56b1add17a8f4817
+    # Custom GCC-linked installer (github.com/mebezac/talos-mac-installer) — stock Talos
+    # 1.13 hangs at cold boot on the T2 Mac (LLD EFI stub, siderolabs/talos#13579).
+    # talhelper appends :${talosVersion} (v1.13.5). Extensions/kernel-args are baked into
+    # this installer, so the factory schematic is no longer referenced here.
+    talosImageURL: ghcr.io/mebezac/talos-mac/installer
     controlPlane: false
     patches:
       - "@./patches/talmac-02/machine-disks.yaml"
-      # Pinned to v1.12.4 — v1.13.0 boot-loops on the 2018 Mac mini (T2)
-      - "@./patches/talmac-02/machine-install.yaml"
     networkInterfaces:
       - deviceSelector:
           hardwareAddr: "3c:cd:36:69:f8:ce"

--- a/kubernetes/bootstrap/talos/talconfig.yaml
+++ b/kubernetes/bootstrap/talos/talconfig.yaml
@@ -4,7 +4,7 @@
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
 talosVersion: v1.13.5
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-kubernetesVersion: v1.35.6
+kubernetesVersion: v1.36.2
 
 clusterName: kubernetes
 endpoint: https://10.25.30.116:6443


### PR DESCRIPTION
## What

Migrate the three T2 Intel Mac mini nodes (talmac-01/02/03) onto the custom
GCC-linked Talos installer so they run **Talos v1.13.5** like the rest of the
cluster, add a reusable `talos-upgrade` skill, and sync `kubernetesVersion` to
**v1.36.2** (the live cluster was already rolled via `talosctl upgrade-k8s`).

## Why the talmacs needed a custom installer

Stock Talos v1.13 **hangs at cold boot** on the 2018 T2 Mac mini: the kernel's
Clang+LLD EFI stub is rejected by Apple's Intel firmware at hand-off
(siderolabs/talos#13579). The fix is a kernel linked with **GNU ld instead of LLD**,
built by `github.com/mebezac/talos-mac-installer` and published to
`ghcr.io/mebezac/talos-mac/installer`.

## Explicitly: do NOT use the GRUB version ladder

An earlier iteration proposed reinstalling from Talos **v1.9.6** (last GRUB-default
release) and laddering up minor-by-minor so GRUB's legacy boot path "dodges" the hang.
**That approach is wrong and must not be used:**

- **It doesn't fix the hang.** The cause is the *kernel's* LLD EFI stub, not the
  bootloader. Talos GRUB (2.14) hands off to that same kernel, so a GRUB-booted v1.13
  kernel hangs too.
- **Any mid-ladder "success" is a kexec false-positive.** In-place `talosctl upgrade`
  kexecs the new kernel (bypassing firmware), so it looks fine until a real power cycle
  — which it does not survive.
- **It's five destructive reinstalls for nothing.** v1.9.6 → 1.10 → 1.11 → 1.12 → 1.13,
  each a full wipe + Longhorn rebuild + schema migration, to arrive at a kernel that
  still hangs on cold boot. A single `talosctl upgrade` onto the custom image replaces
  the whole ladder.

A GCC-linked kernel cold-boots fine under UKI/systemd-boot — no GRUB, no ladder, no
downgrade.

## Changes

- `talconfig.yaml`: all three talmacs point at `ghcr.io/mebezac/talos-mac/installer`,
  v1.12.4 install pins removed; `kubernetesVersion` → `v1.36.2`.
- `patches/talmac-0X/machine-install.yaml` pins deleted (disk patches kept).
- `docs/talmac-1.13-upgrade.md`: runbook rewritten around the custom installer, with an
  explicit "do NOT do the GRUB ladder" section and the in-place-upgrade path.
- `.claude/skills/talos-upgrade/`: new skill capturing the safe node-by-node upgrade
  procedure and the Longhorn gotchas learned during the rollout.

## Rollout status (already applied to the live cluster)

- All 8 nodes on **Talos v1.13.5**, kubelet/apiserver **v1.36.2**, all Ready.
- talmac in-place upgrades report a **non-fatal `BootFFFF`** boot-entry error (Apple EFI
  NVRAM quirk) — systemd-boot still boots the new UKI; verify version after.
- etcd 3/3 healthy, all Longhorn volumes healthy.

## Notes

- This is the bootstrap/Talos layer — **not ArgoCD-managed**. Merging keeps the
  declarative config in sync; the cluster is already upgraded.
- talmac-03's Sabrent USB Longhorn disk was removed (failing enclosure hardware) — not
  part of this diff; tracked separately for a hardware fix.
