### PR TITLE
feat(cilium): upgrade 1.18.4 → 1.19.5

### DIFF
--- a/kubernetes/apps/kube-system/cilium/config/pool.yaml
+++ b/kubernetes/apps/kube-system/cilium/config/pool.yaml
@@ -1,6 +1,6 @@
 ---
-# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/cilium.io/ciliumloadbalancerippool_v2alpha1.json
-apiVersion: cilium.io/v2alpha1
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/cilium.io/ciliumloadbalancerippool_v2.json
+apiVersion: cilium.io/v2
 kind: CiliumLoadBalancerIPPool
 metadata:
   name: pool

--- a/kubernetes/argo/apps/kube-system/cilium.yaml
+++ b/kubernetes/argo/apps/kube-system/cilium.yaml
@@ -15,7 +15,7 @@ spec:
       ref: repo
     - repoURL: https://helm.cilium.io
       chart: cilium
-      targetRevision: 1.18.4
+      targetRevision: 1.19.5
       helm:
         releaseName: cilium
         valueFiles:

--- a/kubernetes/bootstrap/helmfile.yaml
+++ b/kubernetes/bootstrap/helmfile.yaml
@@ -24,7 +24,7 @@ releases:
   - name: cilium
     namespace: kube-system
     chart: cilium/cilium
-    version: 1.18.4
+    version: 1.19.5
     values:
       - ../apps/kube-system/cilium/values.sops.yaml
     needs:


### PR DESCRIPTION
Upgrades Cilium to 1.19.5 (latest), superseding Renovate PRs #1460 (stale, would revert unrelated helmfile charts) and #1805 (1.18.11 patch).

## Changes
- `cilium.yaml` + `helmfile.yaml`: chart 1.18.4 → 1.19.5
- `config/pool.yaml`: `CiliumLoadBalancerIPPool` `v2alpha1` → `v2` (required 1.19 migration; v2 is already the storage version under 1.18, so safe)

## 1.19 breaking-change review vs this cluster
- **CiliumLoadBalancerIPPool v2alpha1→v2** — migrated ✅
- **CiliumL2AnnouncementPolicy** — stays v2alpha1 in 1.19, unchanged ✅
- DNS `**` wildcard, `FromRequires`/`ToRequires`, removed kube-proxy flags — no CiliumNetworkPolicies in repo, N/A
- `policy-default-local-cluster`, clustermesh authMode — no ClusterMesh, N/A
- BGP peering policy, egress gateway, IPsec — not used, N/A
- `values.yaml` uses no removed/renamed flags; `kubeProxyReplacement: true` correct

Recommend merging this and closing #1460 + #1805.